### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -269,7 +269,7 @@ class Publication < ApplicationRecord
   end
 
   def doi_url
-    "http://dx.doi.org/#{self.DOI}"
+    "https://doi.org/#{self.DOI}"
   end
 
   def scholar_url

--- a/app/views/admin/publications/_publication_validation.html.erb
+++ b/app/views/admin/publications/_publication_validation.html.erb
@@ -73,7 +73,7 @@
     <% end %>
     <br >
     <% if not publication.DOI.blank? %>
-      <%= link_to "http://dx.doi.org/#{publication.DOI}" do %>
+      <%= link_to "https://doi.org/#{publication.DOI}" do %>
           <span class="glyphicon glyphicon-link" aria-hidden="true"></span>
       <% end %>
     <% end %>


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). This PR implements that recommendation by updating the code that generates new DOI URLs.

Cheers :-)