### PR TITLE
Add safety net test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,89 @@
+# Mesophotic.org
+
+A Ruby on Rails application that serves as a curated database of scientific publications on mesophotic coral ecosystems.
+
+## Stack
+
+- **Ruby** 2.7 / **Rails** 5.2.8
+- **Database**: SQLite3 (all environments)
+- **Frontend**: Sprockets, Bootstrap 3 (bootstrap-sass), jQuery, Turbolinks, CoffeeScript, SCSS
+- **Auth**: Devise
+- **Admin**: RailsAdmin (mounted at `/admin/db`)
+- **Dev environment**: Nix flake (enter with `nix develop` or direnv)
+
+## Development
+
+### Setup
+
+```sh
+nix develop        # or let direnv handle it
+bundle install
+rails db:setup
+rails s            # starts Puma on port 8765
+```
+
+### Environment variables
+
+Managed via Figaro (`config/application.yml`, gitignored). AWS credentials are needed for S3/DynamoDB in production.
+
+### Tests
+
+Minitest with fixtures. Test generators are disabled (`config.generators.test_framework false`).
+
+```sh
+rails test
+```
+
+### Dependencies
+
+After changing the Gemfile, update the Nix gemset:
+
+```sh
+bundle lock
+bundix
+```
+
+## Architecture
+
+### Key models
+
+- `Publication` — the central model. Heavy use of scopes for search/filtering, HABTM associations to `Location`, `Field`, `Platform`, `Focusgroup`, `Site`, `Species`. Has `friendly_id` slugs and `paper_trail` versioning. PDF attachments via Active Storage.
+- `User` — Devise-based authentication with confirmation.
+
+### Conventions
+
+- ERB templates (not Slim/Haml)
+- Model annotations via the `annotate` gem (schema comments at top of model files)
+- Constants defined on models for enumerations (e.g. `PUBLICATION_TYPES`, `PUBLICATION_FORMATS`)
+- HABTM join tables for many-to-many relationships
+- `before_save` callbacks for creating associated records from form inputs
+- View helpers for formatting and filtering logic
+- `render_async` for deferred partial loading
+- Background jobs via Active Job (default async adapter)
+- Cron via `whenever` gem (`config/schedule.rb`)
+
+### Engines
+
+- `engines/dual_range_slider/` — custom Rails engine for the dual range slider UI component
+
+### Frontend
+
+- Bootstrap 3 grid layout with custom SCSS
+- Bootstrap Icons (recently replaced glyphicons and Font Awesome)
+- jQuery UJS for AJAX
+- Turbolinks for page transitions
+- Asset pipeline via Sprockets; no Webpacker/esbuild/importmap
+
+## Code style
+
+- No linter currently configured. Follow existing patterns in the codebase.
+- Prefer simple, readable code consistent with Rails conventions.
+- Keep views in ERB. Use partials in `app/views/shared/` for reusable components.
+- SQL-heavy scopes in models are fine — this app leans into ActiveRecord.
+
+## Deployment
+
+- Puma (1 worker, 1–3 threads)
+- Production assets served from `assets.mesophotic.org`
+- AWS S3 for Active Storage, DynamoDB for session store
+- New Relic for monitoring (production only)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'uglifier'
 
 # RailsBricks gems
 gem 'bootstrap-sass', '~> 3.4.1'
-gem 'bootstrap-slider-rails'
 gem 'devise', '>= 4.6.0'
 gem 'friendly_id'
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,8 +113,6 @@ GEM
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
-    bootstrap-slider-rails (9.8.0)
-      railties (>= 3.2, < 6.0)
     builder (3.3.0)
     byebug (11.1.3)
     choice (0.2.0)
@@ -380,7 +378,6 @@ DEPENDENCIES
   bcrypt
   bootsnap
   bootstrap-sass (~> 3.4.1)
-  bootstrap-slider-rails
   byebug
   coffee-rails
   country_select

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,7 +14,7 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require bootstrap
-//= require bootstrap-slider
+//= require dual_range
 // = require analytics
 // = require owl.carousel
 // = require wordcloud2

--- a/app/assets/javascripts/dual_range.js
+++ b/app/assets/javascripts/dual_range.js
@@ -1,0 +1,76 @@
+function initDualRange(minInput, maxInput, minDisplay, maxDisplay, hiddenInput, rangeHighlight) {
+  const minRange = parseInt(minInput.min);
+  const maxRange = parseInt(minInput.max);
+  const rangeTag = document.getElementById(minInput.id.replace('_min', '_range_tag'));
+  
+  function updateValues() {
+    let minVal = parseInt(minInput.value);
+    let maxVal = parseInt(maxInput.value);
+    
+    // Ensure min never exceeds max
+    if (minVal > maxVal) {
+      minVal = maxVal;
+      minInput.value = minVal;
+    }
+    
+    // Ensure max never goes below min
+    if (maxVal < minVal) {
+      maxVal = minVal;
+      maxInput.value = maxVal;
+    }
+    
+    // Update display values in the single tag
+    minDisplay.textContent = minVal;
+    maxDisplay.textContent = maxVal;
+    
+    // Update hidden input with comma-separated values
+    hiddenInput.value = minVal + ',' + maxVal;
+    
+    // Update range highlight
+    updateRangeHighlight(minVal, maxVal, minRange, maxRange, rangeHighlight);
+    
+    // Position the single range tag in the center
+    positionRangeTag(minVal, maxVal, minRange, maxRange, rangeTag);
+  }
+  
+  function updateRangeHighlight(minVal, maxVal, minRange, maxRange, highlight) {
+    const range = maxRange - minRange;
+    const leftPercent = ((minVal - minRange) / range) * 100;
+    const rightPercent = ((maxVal - minRange) / range) * 100;
+    
+    highlight.style.left = leftPercent + '%';
+    highlight.style.width = (rightPercent - leftPercent) + '%';
+  }
+  
+  function positionRangeTag(minVal, maxVal, minRange, maxRange, rangeTag) {
+    const container = rangeTag.parentElement;
+    const containerWidth = container.offsetWidth;
+    const range = maxRange - minRange;
+    
+    // Account for thumb width (16px) in positioning calculations
+    const thumbWidth = 16;
+    const trackWidth = containerWidth - thumbWidth;
+    
+    const minPercent = (minVal - minRange) / range;
+    const maxPercent = (maxVal - minRange) / range;
+    
+    // Calculate actual pixel positions accounting for thumb centers
+    const minPixel = (thumbWidth / 2) + (minPercent * trackWidth);
+    const maxPixel = (thumbWidth / 2) + (maxPercent * trackWidth);
+    
+    // Position tag at center of the actual thumb positions
+    const centerPixel = (minPixel + maxPixel) / 2;
+    const centerPercent = (centerPixel / containerWidth) * 100;
+    
+    rangeTag.style.left = centerPercent + '%';
+    rangeTag.style.transition = 'none';
+    rangeTag.offsetHeight;
+  }
+  
+  // Simple event handling - let the browser handle the overlapping
+  minInput.addEventListener('input', updateValues);
+  maxInput.addEventListener('input', updateValues);
+  
+  // Initialize values on page load
+  updateValues();
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,9 +3,7 @@
  *
  *= require_self
  *= require owl.carousel
- *= require bootstrap-slider
  */
-
 @import "owl.theme.default";
 @import "railsbricks_custom";
 
@@ -86,17 +84,174 @@ span.bi-link {
 
   .right { text-align: right; }
 
-  .slider {
-    &.slider-horizontal {
+  .dual-range-input {
+    width: 100%;
+
+    &::-webkit-slider-thumb {
+      background: rgb(124, 181, 236);
+    }
+
+    &::-moz-range-thumb {
+      background: rgb(124, 181, 236);
+    }
+
+    &::-webkit-slider-track {
+      background: rgb(149, 206, 255);
+    }
+
+    &::-moz-range-track {
+      background: rgb(149, 206, 255);
+    }
+  }
+
+  .dual-range-wrapper {
+    width: 100%;
+    display: flex;
+    align-items: center; // Center labels with track
+    gap: 12px;
+    padding-top: 15px; // Minimal space for tag above track
+
+    .range-label-min,
+    .range-label-max {
+      font-size: 1.2rem;
+      color: #000000;
+      font-weight: bold;
+      flex-shrink: 0;
+    }
+  }
+
+  .dual-range-container {
+    position: relative;
+    width: 100%;
+    height: 50px; // Back to original height
+    display: flex;
+    align-items: center;
+
+    .slider-track {
+      position: absolute;
+      top: 50%;
+      left: 0;
+      right: 0;
+      height: 8px;
+      background-color: #dee2e6;
+      border-radius: 4px;
+      transform: translateY(-50%);
+    }
+
+    .slider-range {
+      position: absolute;
+      top: 50%;
+      height: 8px;
+      background-color: #8bb7e9;
+      border-radius: 4px;
+      transform: translateY(-50%);
+    }
+
+    .dual-range-input {
+      position: absolute;
+      top: 0;
       width: 100%;
+      height: 100%;
+      -webkit-appearance: none;
+      appearance: none;
+      background: transparent;
+      outline: none;
+      cursor: pointer;
+      pointer-events: none; // Disable pointer events on track
+
+      &::-webkit-slider-track {
+        -webkit-appearance: none;
+        background: transparent;
+        height: 8px;
+        margin-top: calc(50% - 4px); // Center the 8px track vertically
+      }
+
+      &::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        height: 16px;
+        width: 16px;
+        background: #0d6efd;
+        border-radius: 50%;
+        cursor: pointer;
+        border: 0;
+        box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+        transition: all 0.15s ease-in-out;
+        pointer-events: auto; // Enable pointer events on thumb
+
+        &:hover {
+          background-color: #0b5ed7;
+          transform: scale(1.1);
+        }
+
+        &:active {
+          background-color: #0a58ca;
+          transform: scale(1.2);
+        }
+      }
+
+      &::-moz-range-track {
+        background: transparent;
+        height: 8px;
+        border: 0;
+      }
+
+      &::-moz-range-thumb {
+        height: 16px;
+        width: 16px;
+        background: #0d6efd;
+        border-radius: 50%;
+        cursor: pointer;
+        border: 0;
+        box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+        transition: all 0.15s ease-in-out;
+        pointer-events: auto; // Enable pointer events on thumb
+        -moz-appearance: none;
+
+        &:hover {
+          background-color: #0b5ed7;
+          transform: scale(1.1);
+        }
+
+        &:active {
+          background-color: #0a58ca;
+          transform: scale(1.2);
+        }
+      }
+
+      &.dual-range-min {
+        z-index: 1;
+      }
+
+      &.dual-range-max {
+        z-index: 2;
+      }
     }
 
-    .slider-handle {
-      background: rgb(124, 181, 236)
-    }
+    .range-tag {
+      position: absolute;
+      background: #212529;
+      color: white;
+      padding: 6px 10px;
+      border-radius: 4px;
+      font-size: 1.2rem;
+      font-weight: normal;
+      white-space: nowrap;
+      pointer-events: none;
+      z-index: 10;
+      top: 50%;
+      transform: translate(-50%, -140%); // Position above the center of the highlighted range
+      border: 1px solid #dee2e6;
 
-    .slider-selection {
-      background: rgb(149, 206, 255)
+      // Arrow pointing down
+      &::after {
+        content: '';
+        position: absolute;
+        top: 100%;
+        left: 50%;
+        transform: translateX(-50%);
+        border: 4px solid transparent;
+        border-top-color: #212529;
+      }
     }
   }
 }

--- a/app/helpers/dual_range_helper.rb
+++ b/app/helpers/dual_range_helper.rb
@@ -1,0 +1,45 @@
+module DualRangeHelper
+  def dual_range_slider(name, options = {})
+    defaults = {
+      min: 0,
+      max: 100,
+      step: 1,
+      value: nil,
+      class: '',
+      suffix: '',
+      id: nil,
+      min_label: nil,
+      max_label: nil
+    }
+    
+    opts = defaults.merge(options)
+    
+    # Parse current value or use defaults
+    current_value = opts[:value] || "#{opts[:min]},#{opts[:max]}"
+    min_val, max_val = current_value.split(',').map(&:to_i)
+    
+    # Generate unique IDs if not provided
+    base_id = opts[:id] || name.to_s.gsub(/[\[\]]/, '_').gsub('__', '_')
+    min_id = "#{base_id}_min"
+    max_id = "#{base_id}_max"
+    hidden_id = "#{base_id}_hidden"
+    highlight_id = "#{base_id}_highlight"
+    min_display_id = "#{base_id}_min_display"
+    max_display_id = "#{base_id}_max_display"
+    
+    render partial: 'shared/dual_range_slider', locals: {
+      name: name,
+      opts: opts,
+      min_val: min_val,
+      max_val: max_val,
+      current_value: current_value,
+      base_id: base_id,
+      min_id: min_id,
+      max_id: max_id,
+      hidden_id: hidden_id,
+      highlight_id: highlight_id,
+      min_display_id: min_display_id,
+      max_display_id: max_display_id
+    }
+  end
+end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/home_title" %>
 
 <div class="panel panel-default">
-  <div class="panel-body  background_image" align="center">
+  <div class="panel-body background_image" align="center">
     <div class="row">&nbsp;</div>
     <div class="row">
       <div class="col-sm-1">&nbsp;</div>

--- a/app/views/publications/_search_field.html.erb
+++ b/app/views/publications/_search_field.html.erb
@@ -40,46 +40,32 @@
       <div class="panel-body">
         <div class="row">
           <div class="col-sm-12">
-            <div class="col-sm-1 right">
-              <b><%= Publication.min_year %></b>
-            </div>
-            <div class="col-sm-9">
-              <input
-                type="text"
-                id="year_slider"
-                name="search_params[year_range]"
-                data-provide="slider"
-                data-slider-min="<%= Publication.min_year %>"
-                data-slider-max="<%= Publication.max_year %>"
-                data-slider-step="1"
-                data-slider-value="[<%= params[:search_params][:year_range] %>]">
-              <script>$('#year_slider').slider();</script>
-            </div>
-            <div class="col-sm-1">
-              <b><%= Publication.max_year %></b>
-            </div>
+            <% 
+              year_range = params.dig(:search_params, :year_range) || "#{Publication.min_year},#{Publication.max_year}"
+            %>
+            <%= dual_range_slider('search_params[year_range]', {
+              min: Publication.min_year,
+              max: Publication.max_year,
+              step: 1,
+              value: year_range,
+              id: 'year_slider'
+            }) %>
           </div>
         </div>
         <div class="row">
           <div class="col-sm-12">
-            <div class="col-sm-1 right">
-              <b>0&nbsp;m</b>
-            </div>
-            <div class="col-sm-9">
-              <input
-                type="text"
-                id="depth_slider"
-                name="search_params[depth_range]"
-                data-provide="slider"
-                data-slider-min="0"
-                data-slider-max="500"
-                data-slider-step="5"
-                data-slider-value="[<%= params[:search_params][:depth_range] %>]">
-              <script>$('#depth_slider').slider();</script>
-            </div>
-            <div class="col-sm-1">
-              <b>>&nbsp;500&nbsp;m</b>
-            </div>
+            <% 
+              depth_range = params.dig(:search_params, :depth_range) || "0,500"
+            %>
+            <%= dual_range_slider('search_params[depth_range]', {
+              min: 0,
+              max: 500,
+              step: 5,
+              value: depth_range,
+              id: 'depth_slider',
+              suffix: 'm',
+              max_label: '500m+'
+            }) %>
           </div>
         </div>
         <div class="row">

--- a/app/views/shared/_dual_range_slider.html.erb
+++ b/app/views/shared/_dual_range_slider.html.erb
@@ -1,0 +1,52 @@
+<div class="dual-range-wrapper">
+  <span class="range-label-min"><%= opts[:min_label] || "#{opts[:min]}#{opts[:suffix]}" %></span>
+  
+  <div class="dual-range-container <%= opts[:class] %>" data-min="<%= opts[:min] %>" data-max="<%= opts[:max] %>">
+    <div class="slider-track"></div>
+    <div class="slider-range" id="<%= highlight_id %>"></div>
+    
+    <input
+      type="range"
+      class="dual-range-input dual-range-min"
+      id="<%= min_id %>"
+      name="<%= name %>_min"
+      min="<%= opts[:min] %>"
+      max="<%= opts[:max] %>"
+      step="<%= opts[:step] %>"
+      value="<%= min_val %>">
+      
+    <input
+      type="range"
+      class="dual-range-input dual-range-max"
+      id="<%= max_id %>"
+      name="<%= name %>_max"
+      min="<%= opts[:min] %>"
+      max="<%= opts[:max] %>"
+      step="<%= opts[:step] %>"
+      value="<%= max_val %>">
+      
+    <input type="hidden" name="<%= name %>" id="<%= hidden_id %>" value="<%= current_value %>">
+    
+    <!-- Single centered range tag -->
+    <div class="range-tag" id="<%= base_id %>_range_tag">
+      <span id="<%= min_display_id %>"><%= min_val %></span><%= opts[:suffix] %> - <span id="<%= max_display_id %>"><%= max_val %></span><%= opts[:suffix] %>
+    </div>
+  </div>
+  
+  <span class="range-label-max"><%= opts[:max_label] || "#{opts[:max]}#{opts[:suffix]}" %></span>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    const minInput = document.getElementById('<%= min_id %>');
+    const maxInput = document.getElementById('<%= max_id %>');
+    const minDisplay = document.getElementById('<%= min_display_id %>');
+    const maxDisplay = document.getElementById('<%= max_display_id %>');
+    const hiddenInput = document.getElementById('<%= hidden_id %>');
+    const rangeHighlight = document.getElementById('<%= highlight_id %>');
+    
+    if (minInput && maxInput) {
+      initDualRange(minInput, maxInput, minDisplay, maxDisplay, hiddenInput, rangeHighlight);
+    }
+  });
+</script>

--- a/docs/superpowers/plans/2026-03-25-phase-0-safety-net-tests.md
+++ b/docs/superpowers/plans/2026-03-25-phase-0-safety-net-tests.md
@@ -1,0 +1,1709 @@
+# Phase 0: Safety Net Tests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish a baseline regression test suite that describes current application behaviour, so that upgrade phases 1–5 can detect breakage.
+
+**Architecture:** Minitest with fixtures (matching the existing test setup). Model tests for validations/associations/scopes/callbacks, controller integration tests for HTTP responses and auth gates, helper tests for output correctness. No factories, no RSpec — keep it consistent with what's already here.
+
+**Tech Stack:** Rails 5.2 Minitest, fixtures (YAML), ActionDispatch::IntegrationTest for controllers.
+
+**VCS:** jj. Create bookmark `ryan/test-safety-net` from current `ryan/bootstrap-3` head.
+
+**Spec:** `docs/superpowers/specs/2026-03-25-rails-modernization-design.md`
+
+---
+
+## File Structure
+
+**New fixture files** (all in `test/fixtures/`):
+- `users.yml` — admin, editor, regular, locked users
+- `organisations.yml` — one organisation
+- `journals.yml` — open access and closed journals
+- `locations.yml` — two locations with coordinates
+- `sites.yml` — one site with location
+- `focusgroups.yml` — two focusgroups
+- `fields.yml` — two fields
+- `platforms.yml` — two platforms
+- `species.yml` — one species with focusgroup
+- `posts.yml` — one published, one drafted
+- `photos.yml` — one creative commons, one regular
+- `validations.yml` — enough to test 2-threshold
+
+**Modified fixture files:**
+- `test/fixtures/publications.yml` — add scientific article and chapter fixtures alongside existing Led Zeppelin fixtures
+
+**New test files:**
+- `test/models/user_test.rb`
+- `test/models/post_test.rb`
+- `test/models/photo_test.rb`
+- `test/models/species_test.rb`
+- `test/models/location_test.rb`
+- `test/models/journal_test.rb`
+- `test/models/validation_test.rb`
+- `test/controllers/pages_controller_test.rb`
+- `test/controllers/stats_controller_test.rb`
+- `test/controllers/admin/base_controller_test.rb`
+- `test/controllers/admin/users_controller_test.rb`
+- `test/helpers/application_helper_test.rb`
+- `test/helpers/publications_helper_test.rb`
+- `test/helpers/dual_range_helper_test.rb`
+
+**Modified test files:**
+- `test/test_helper.rb` — add Devise integration test helpers
+- `test/models/publication_test.rb` — add validation, association, callback, and instance method tests
+- `test/controllers/publications_controller_test.rb` — convert to integration tests, add HTTP tests
+
+---
+
+### Task 1: Create jj bookmark and set up test infrastructure
+
+**Files:**
+- Modify: `test/test_helper.rb`
+
+- [ ] **Step 1: Create jj bookmark**
+
+```bash
+jj bookmark create ryan/test-safety-net
+```
+
+- [ ] **Step 2: Add Devise test helpers to test_helper.rb**
+
+Add `include Devise::Test::IntegrationHelpers` to a new integration test base class. This lets controller tests sign in users.
+
+```ruby
+# test/test_helper.rb
+ENV['RAILS_ENV'] = 'test'
+require File.expand_path('../../config/environment', __FILE__)
+require 'rails/test_help'
+
+class ActiveSupport::TestCase
+  fixtures :all
+end
+
+class ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+end
+```
+
+- [ ] **Step 3: Run existing tests to verify they still pass**
+
+Run: `rails test`
+Expected: 17 tests, 0 failures (existing publication and controller tests)
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "Add Devise integration test helpers to test_helper"
+jj new
+```
+
+---
+
+### Task 2: Create core fixture files
+
+**Files:**
+- Create: `test/fixtures/organisations.yml`
+- Create: `test/fixtures/users.yml`
+- Create: `test/fixtures/journals.yml`
+- Create: `test/fixtures/locations.yml`
+- Create: `test/fixtures/sites.yml`
+- Create: `test/fixtures/focusgroups.yml`
+- Create: `test/fixtures/fields.yml`
+- Create: `test/fixtures/platforms.yml`
+- Create: `test/fixtures/species.yml`
+
+- [ ] **Step 1: Create organisations fixture**
+
+```yaml
+# test/fixtures/organisations.yml
+csiro:
+  name: "CSIRO"
+  country: "Australia"
+```
+
+- [ ] **Step 2: Create users fixture**
+
+Users need `encrypted_password` for Devise. Use a pre-generated bcrypt hash for "password123". Devise's `confirmed_at` must be set for login to work.
+
+```yaml
+# test/fixtures/users.yml
+admin_user:
+  email: "admin@example.com"
+  encrypted_password: "$2a$11$eFmKFjWA8WmMkBkRUMRHMOlGZCpjPcIFjkJsXGWvfYTME3FvT4Gm6"
+  first_name: "Admin"
+  last_name: "User"
+  admin: true
+  editor: false
+  locked: false
+  confirmed_at: "2024-01-01 00:00:00"
+  organisation: csiro
+
+editor_user:
+  email: "editor@example.com"
+  encrypted_password: "$2a$11$eFmKFjWA8WmMkBkRUMRHMOlGZCpjPcIFjkJsXGWvfYTME3FvT4Gm6"
+  first_name: "Editor"
+  last_name: "User"
+  admin: false
+  editor: true
+  locked: false
+  confirmed_at: "2024-01-01 00:00:00"
+
+regular_user:
+  email: "regular@example.com"
+  encrypted_password: "$2a$11$eFmKFjWA8WmMkBkRUMRHMOlGZCpjPcIFjkJsXGWvfYTME3FvT4Gm6"
+  first_name: "Regular"
+  last_name: "User"
+  admin: false
+  editor: false
+  locked: false
+  confirmed_at: "2024-01-01 00:00:00"
+
+locked_user:
+  email: "locked@example.com"
+  encrypted_password: "$2a$11$eFmKFjWA8WmMkBkRUMRHMOlGZCpjPcIFjkJsXGWvfYTME3FvT4Gm6"
+  first_name: "Locked"
+  last_name: "User"
+  admin: false
+  editor: false
+  locked: true
+  confirmed_at: "2024-01-01 00:00:00"
+```
+
+Note: The bcrypt hash above is for the password "password123". Generate a real one in the Rails console if this doesn't work: `User.new(password: "password123").encrypted_password`.
+
+- [ ] **Step 3: Create journals fixture**
+
+```yaml
+# test/fixtures/journals.yml
+open_journal:
+  name: "Open Access Journal"
+  open_access: true
+
+closed_journal:
+  name: "Closed Journal"
+  open_access: false
+```
+
+- [ ] **Step 4: Create locations fixture**
+
+```yaml
+# test/fixtures/locations.yml
+great_barrier_reef:
+  description: "Great Barrier Reef"
+  short_description: "GBR;Australia"
+  latitude: -18.2861
+  longitude: 147.7000
+
+red_sea:
+  description: "Red Sea"
+  short_description: "Red Sea;Middle East"
+  latitude: 27.2000
+  longitude: 34.8000
+```
+
+- [ ] **Step 5: Create sites fixture**
+
+```yaml
+# test/fixtures/sites.yml
+osprey_reef:
+  site_name: "Osprey Reef"
+  latitude: -13.8833
+  longitude: 146.5667
+  estimated: false
+  location: great_barrier_reef
+```
+
+- [ ] **Step 6: Create focusgroups, fields, platforms fixtures**
+
+```yaml
+# test/fixtures/focusgroups.yml
+fish:
+  description: "Fish"
+  short_description: "Fish"
+
+corals:
+  description: "Corals"
+  short_description: "Corals"
+```
+
+```yaml
+# test/fixtures/fields.yml
+ecology:
+  description: "Ecology"
+  short_description: "Ecology"
+
+genetics:
+  description: "Genetics"
+  short_description: "Genetics"
+```
+
+```yaml
+# test/fixtures/platforms.yml
+scuba:
+  description: "SCUBA diving"
+  short_description: "SCUBA"
+
+rov:
+  description: "Remotely Operated Vehicle"
+  short_description: "ROV"
+```
+
+- [ ] **Step 7: Create species fixture**
+
+```yaml
+# test/fixtures/species.yml
+chromis_margaritifer:
+  name: "Chromis margaritifer"
+  focusgroup: fish
+```
+
+- [ ] **Step 8: Run tests to verify fixtures load without errors**
+
+Run: `rails test`
+Expected: 17 tests, 0 failures. Fixtures load without foreign key or uniqueness errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+jj describe -m "Add core fixture files for users, journals, locations, species, and related models"
+jj new
+```
+
+---
+
+### Task 3: Create publication-related fixtures (posts, photos, validations) and expand publications
+
+**Files:**
+- Modify: `test/fixtures/publications.yml`
+- Create: `test/fixtures/posts.yml`
+- Create: `test/fixtures/photos.yml`
+- Create: `test/fixtures/validations.yml`
+
+- [ ] **Step 1: Add scientific and chapter publications to existing fixture**
+
+Append to `test/fixtures/publications.yml`:
+
+```yaml
+scientific_article:
+  title: "Mesophotic coral ecosystems of the Great Barrier Reef"
+  authors: "Smith, J.; Jones, A.; Williams, B."
+  publication_year: 2020
+  publication_type: "scientific"
+  publication_format: "article"
+  abstract: "This study examines mesophotic coral reef ecosystems at depths of 30-150m."
+  contents: "Mesophotic coral ecosystems (MCEs) are deep reef communities found at depths of 30-150m."
+  min_depth: 30
+  max_depth: 150
+  DOI: "10.1234/meso.2020"
+  original_data: true
+  mesophotic: true
+  mce: true
+  journal: open_journal
+  contributor: admin_user
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"
+
+book_chapter:
+  title: "Chapter 5: Deep Reef Refugia"
+  authors: "Brown, C.; Davis, D."
+  publication_year: 2019
+  publication_type: "scientific"
+  publication_format: "chapter"
+  book_title: "Coral Reef Science"
+  book_publisher: "Academic Press"
+  book_authors: "Editor, E."
+  min_depth: 60
+  max_depth: 200
+  original_data: true
+  mesophotic: true
+  mce: true
+  journal: closed_journal
+  contributor: editor_user
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"
+```
+
+- [ ] **Step 2: Create posts fixture**
+
+```yaml
+# test/fixtures/posts.yml
+published_post:
+  title: "Behind the Science: Mesophotic Reefs"
+  content_md: "This is the **markdown** content of the post."
+  content_html: "<p>This is the <strong>markdown</strong> content of the post.</p>"
+  draft: false
+  post_type: "behind_the_science"
+  user: admin_user
+  featured_user: regular_user
+  featured_publication: scientific_article
+  slug: "behind-the-science-mesophotic-reefs"
+
+drafted_post:
+  title: "Draft Announcement"
+  content_md: "This is a draft post."
+  content_html: "<p>This is a draft post.</p>"
+  draft: true
+  post_type: "announcement"
+  user: editor_user
+  featured_user: editor_user
+  slug: "draft-announcement"
+```
+
+- [ ] **Step 3: Create photos fixture**
+
+```yaml
+# test/fixtures/photos.yml
+cc_photo:
+  credit: "Photographer A"
+  description: "Mesophotic reef at 60m depth"
+  depth: 60
+  creative_commons: true
+  underwater: true
+  showcases_location: true
+  media_gallery: true
+  photographer: regular_user
+  location: great_barrier_reef
+
+regular_photo:
+  credit: "Photographer B"
+  description: "Coral specimen"
+  depth: 30
+  creative_commons: false
+  underwater: false
+  showcases_location: false
+  media_gallery: false
+  photographer: admin_user
+```
+
+- [ ] **Step 4: Create validations fixture**
+
+```yaml
+# test/fixtures/validations.yml
+validation_one:
+  validatable: scientific_article
+  validatable_type: Publication
+  user: admin_user
+  created_at: "2025-01-01 00:00:00"
+  updated_at: "2025-01-01 00:00:00"
+
+validation_two:
+  validatable: scientific_article
+  validatable_type: Publication
+  user: editor_user
+  created_at: "2025-01-01 00:00:00"
+  updated_at: "2025-01-01 00:00:00"
+
+validation_three:
+  validatable: book_chapter
+  validatable_type: Publication
+  user: admin_user
+  created_at: "2025-01-01 00:00:00"
+  updated_at: "2025-01-01 00:00:00"
+```
+
+Note: Polymorphic associations in fixtures require the `_type` field set explicitly as a separate column. Timestamps are set explicitly to ensure the `validated` scope's `validations.updated_at >= publications.updated_at` comparison works deterministically.
+
+- [ ] **Step 5: Run tests**
+
+Run: `rails test`
+Expected: 17 tests, 0 failures. All fixtures load correctly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj describe -m "Add publication, post, photo, and validation fixtures"
+jj new
+```
+
+---
+
+### Task 4: Publication model tests — validations and associations
+
+**Files:**
+- Modify: `test/models/publication_test.rb`
+
+- [ ] **Step 1: Add validation tests**
+
+Add to `test/models/publication_test.rb`:
+
+```ruby
+test "requires title" do
+  pub = Publication.new(authors: "Author", publication_year: 2020, contributor: users(:admin_user))
+  assert_not pub.valid?
+  assert_includes pub.errors[:title], "can't be blank"
+end
+
+test "requires authors" do
+  pub = Publication.new(title: "Title", publication_year: 2020, contributor: users(:admin_user))
+  assert_not pub.valid?
+  assert_includes pub.errors[:authors], "can't be blank"
+end
+
+test "requires publication_year" do
+  pub = Publication.new(title: "Title", authors: "Author", contributor: users(:admin_user))
+  assert_not pub.valid?
+  assert_includes pub.errors[:publication_year], "can't be blank"
+end
+
+test "valid publication saves" do
+  pub = Publication.new(
+    title: "Valid Publication",
+    authors: "Author A",
+    publication_year: 2020,
+    contributor: users(:admin_user)
+  )
+  assert pub.valid?
+end
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `rails test test/models/publication_test.rb`
+Expected: All tests pass (existing + new)
+
+- [ ] **Step 3: Add association tests**
+
+```ruby
+test "belongs to journal" do
+  pub = publications(:scientific_article)
+  assert_equal journals(:open_journal), pub.journal
+end
+
+test "journal is optional" do
+  pub = publications(:one)
+  assert_nil pub.journal
+  assert pub.valid?
+end
+
+test "belongs to contributor" do
+  pub = publications(:scientific_article)
+  assert_equal users(:admin_user), pub.contributor
+end
+
+test "has and belongs to many users" do
+  pub = publications(:scientific_article)
+  pub.users << users(:regular_user)
+  assert_includes pub.users, users(:regular_user)
+end
+
+test "has many validations" do
+  pub = publications(:scientific_article)
+  assert_equal 2, pub.validations.count
+end
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `rails test test/models/publication_test.rb`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "Add Publication model validation and association tests"
+jj new
+```
+
+---
+
+### Task 5: Publication model tests — instance methods and callbacks
+
+**Files:**
+- Modify: `test/models/publication_test.rb`
+
+- [ ] **Step 1: Add instance method tests**
+
+```ruby
+test "open_access? returns true when journal is open access" do
+  pub = publications(:scientific_article)
+  assert pub.open_access?
+end
+
+test "open_access? returns false when journal is not open access" do
+  pub = publications(:book_chapter)
+  assert_equal journals(:closed_journal), pub.journal
+  assert_not pub.open_access?
+end
+
+test "open_access? returns false when no journal" do
+  pub = publications(:one)
+  assert_nil pub.journal
+  assert_not pub.open_access?
+end
+
+test "scientific_article? for scientific article" do
+  pub = publications(:scientific_article)
+  assert pub.scientific_article?
+end
+
+test "scientific_article? false for chapter" do
+  pub = publications(:book_chapter)
+  assert_not pub.scientific_article?
+end
+
+test "chapter? for chapter format" do
+  pub = publications(:book_chapter)
+  assert pub.chapter?
+end
+
+test "chapter? false for article" do
+  pub = publications(:scientific_article)
+  assert_not pub.chapter?
+end
+
+test "doi_url returns formatted DOI link" do
+  pub = publications(:scientific_article)
+  assert_equal "https://doi.org/10.1234/meso.2020", pub.doi_url
+end
+
+test "scholar_url returns Google Scholar link with DOI" do
+  pub = publications(:scientific_article)
+  url = pub.scholar_url
+  assert_match /scholar\.google\.com/, url
+  assert_match /10\.1234/, url
+end
+
+test "short_citation formats authors and year" do
+  pub = publications(:scientific_article)
+  citation = pub.short_citation
+  assert_match /Smith/, citation
+  assert_match /2020/, citation
+end
+
+test "title_truncated truncates long titles" do
+  pub = publications(:scientific_article)
+  assert pub.title_truncated.length <= 73  # 70 + "..."
+end
+
+test "validated? returns true with 2+ validations" do
+  pub = publications(:scientific_article)
+  assert pub.validated?
+end
+
+test "validated? returns false with fewer than 2 validations" do
+  pub = publications(:book_chapter)
+  assert_not pub.validated?
+end
+```
+
+- [ ] **Step 2: Add callback test**
+
+```ruby
+test "create_journal_from_name creates journal on save" do
+  pub = Publication.new(
+    title: "Test",
+    authors: "Author",
+    publication_year: 2020,
+    contributor: users(:admin_user),
+    new_journal_name: "Brand New Journal"
+  )
+  assert_difference "Journal.count", 1 do
+    pub.save!
+  end
+  assert_equal "Brand New Journal", pub.journal.name
+end
+
+test "create_journal_from_name does nothing when name blank" do
+  pub = Publication.new(
+    title: "Test",
+    authors: "Author",
+    publication_year: 2020,
+    contributor: users(:admin_user),
+    new_journal_name: ""
+  )
+  assert_no_difference "Journal.count" do
+    pub.save!
+  end
+end
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `rails test test/models/publication_test.rb`
+Expected: All pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+jj describe -m "Add Publication instance method and callback tests"
+jj new
+```
+
+---
+
+### Task 6: Publication model tests — scopes
+
+**Files:**
+- Modify: `test/models/publication_test.rb`
+
+- [ ] **Step 1: Add scope tests**
+
+```ruby
+test "validated scope returns publications with 2+ validations" do
+  validated = Publication.validated
+  assert_includes validated, publications(:scientific_article)
+  assert_not_includes validated, publications(:book_chapter)
+end
+
+test "unvalidated scope returns publications with fewer than 2 validations" do
+  unvalidated = Publication.unvalidated
+  assert_includes unvalidated, publications(:book_chapter)
+  assert_not_includes unvalidated, publications(:scientific_article)
+end
+
+test "latest scope returns publications ordered by year desc" do
+  latest = Publication.latest(3)
+  assert_equal 3, latest.length
+  assert latest.first.publication_year >= latest.last.publication_year
+end
+
+test "statistics scope filters by status and year" do
+  stats = Publication.statistics(:all, 2025)
+  assert stats.is_a?(ActiveRecord::Relation)
+end
+
+test "annual_counts groups by year" do
+  counts = Publication.annual_counts
+  assert counts.is_a?(Hash)
+end
+
+test "max_year returns highest publication year" do
+  assert_equal 2020, Publication.max_year
+end
+
+test "min_year returns lowest publication year" do
+  assert_equal 1969, Publication.min_year
+end
+
+test "max_depth returns highest max_depth" do
+  assert Publication.max_depth.is_a?(Integer)
+end
+
+test "min_depth returns lowest min_depth" do
+  assert Publication.min_depth.is_a?(Integer)
+end
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `rails test test/models/publication_test.rb`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "Add Publication scope tests"
+jj new
+```
+
+---
+
+### Task 7: User model tests
+
+**Files:**
+- Create: `test/models/user_test.rb`
+
+- [ ] **Step 1: Write the test file**
+
+```ruby
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  # Validations
+  test "requires first_name" do
+    user = User.new(last_name: "Test", email: "test@example.com", password: "password123")
+    assert_not user.valid?
+    assert_includes user.errors[:first_name], "can't be blank"
+  end
+
+  test "requires last_name" do
+    user = User.new(first_name: "Test", email: "test@example.com", password: "password123")
+    assert_not user.valid?
+    assert_includes user.errors[:last_name], "can't be blank"
+  end
+
+  test "requires valid email" do
+    user = User.new(first_name: "Test", last_name: "User", email: "notanemail", password: "password123")
+    assert_not user.valid?
+    assert user.errors[:email].any?
+  end
+
+  test "validates website format when present" do
+    user = users(:regular_user)
+    user.website = "not-a-url"
+    assert_not user.valid?
+  end
+
+  test "allows blank website" do
+    user = users(:regular_user)
+    user.website = ""
+    assert user.valid?
+  end
+
+  # Instance methods
+  test "editor_or_admin? true for admin" do
+    assert users(:admin_user).editor_or_admin?
+  end
+
+  test "editor_or_admin? true for editor" do
+    assert users(:editor_user).editor_or_admin?
+  end
+
+  test "editor_or_admin? false for regular user" do
+    assert_not users(:regular_user).editor_or_admin?
+  end
+
+  test "full_name returns last, first" do
+    user = users(:admin_user)
+    assert_equal "User, Admin", user.full_name
+  end
+
+  test "full_name_normal returns first last" do
+    user = users(:admin_user)
+    assert_equal "Admin User", user.full_name_normal
+  end
+
+  # Associations
+  test "belongs to organisation" do
+    user = users(:admin_user)
+    assert_equal organisations(:csiro), user.organisation
+  end
+
+  test "organisation is optional" do
+    user = users(:regular_user)
+    assert_nil user.organisation
+    assert user.valid?
+  end
+
+  # Pagination
+  test "paginates at 100" do
+    assert_equal 100, User.default_per_page
+  end
+
+  # Callback
+  test "create_organisation_from_name creates organisation on save" do
+    user = users(:regular_user)
+    user.new_organisation_name = "New Org"
+    assert_difference "Organisation.count", 1 do
+      user.save!
+    end
+    assert_equal "New Org", user.organisation.name
+  end
+end
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `rails test test/models/user_test.rb`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "Add User model tests"
+jj new
+```
+
+---
+
+### Task 8: Post model tests
+
+**Files:**
+- Create: `test/models/post_test.rb`
+
+- [ ] **Step 1: Write the test file**
+
+```ruby
+require 'test_helper'
+
+class PostTest < ActiveSupport::TestCase
+  # Validations
+  test "requires title" do
+    post = Post.new(content_md: "Content", post_type: "announcement", user: users(:admin_user), featured_user: users(:admin_user))
+    assert_not post.valid?
+    assert_includes post.errors[:title], "can't be blank"
+  end
+
+  test "requires content_md" do
+    post = Post.new(title: "Title", post_type: "announcement", user: users(:admin_user), featured_user: users(:admin_user))
+    assert_not post.valid?
+    assert_includes post.errors[:content_md], "can't be blank"
+  end
+
+  test "requires post_type" do
+    post = Post.new(title: "Title", content_md: "Content", user: users(:admin_user), featured_user: users(:admin_user))
+    assert_not post.valid?
+    assert_includes post.errors[:post_type], "can't be blank"
+  end
+
+  test "requires featured_publication for behind_the_science" do
+    post = Post.new(
+      title: "BTS Post",
+      content_md: "Content",
+      post_type: "behind_the_science",
+      user: users(:admin_user),
+      featured_user: users(:admin_user)
+    )
+    assert_not post.valid?
+    assert_includes post.errors[:featured_publication_id], "can't be blank"
+  end
+
+  test "requires featured_user for early_career" do
+    post = Post.new(
+      title: "EC Post",
+      content_md: "Content",
+      post_type: "early_career",
+      user: users(:admin_user)
+    )
+    assert_not post.valid?
+    assert_includes post.errors[:featured_user_id], "can't be blank"
+  end
+
+  test "title must be unique" do
+    post = Post.new(
+      title: posts(:published_post).title,
+      content_md: "Content",
+      post_type: "announcement",
+      user: users(:admin_user),
+      featured_user: users(:admin_user)
+    )
+    assert_not post.valid?
+    assert_includes post.errors[:title], "has already been taken"
+  end
+
+  # Callback: markdown to HTML
+  test "renders markdown to HTML on save" do
+    post = Post.new(
+      title: "Markdown Test Post",
+      content_md: "This is **bold** text.",
+      post_type: "announcement",
+      user: users(:admin_user),
+      featured_user: users(:admin_user)
+    )
+    post.save!
+    assert_match "<strong>bold</strong>", post.content_html
+  end
+
+  # Scopes
+  test "published scope returns non-draft posts" do
+    published = Post.published
+    assert_includes published, posts(:published_post)
+    assert_not_includes published, posts(:drafted_post)
+  end
+
+  test "drafted scope returns draft posts" do
+    drafted = Post.drafted
+    assert_includes drafted, posts(:drafted_post)
+    assert_not_includes drafted, posts(:published_post)
+  end
+
+  test "latest scope limits results" do
+    latest = Post.latest(1)
+    assert_equal 1, latest.length
+  end
+
+  # Instance methods
+  test "category returns human-readable name" do
+    post = posts(:published_post)
+    assert_equal "Behind the science", post.category
+  end
+
+  # FriendlyId
+  test "generates slug from title" do
+    post = Post.new(
+      title: "A New Unique Post Title",
+      content_md: "Content here",
+      post_type: "announcement",
+      user: users(:admin_user),
+      featured_user: users(:admin_user)
+    )
+    post.save!
+    assert_equal "a-new-unique-post-title", post.slug
+  end
+end
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `rails test test/models/post_test.rb`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "Add Post model tests"
+jj new
+```
+
+---
+
+### Task 9: Remaining model tests (Photo, Species, Location, Journal, Validation)
+
+**Files:**
+- Create: `test/models/photo_test.rb`
+- Create: `test/models/species_test.rb`
+- Create: `test/models/location_test.rb`
+- Create: `test/models/journal_test.rb`
+- Create: `test/models/validation_test.rb`
+
+- [ ] **Step 1: Write Photo model tests**
+
+```ruby
+# test/models/photo_test.rb
+require 'test_helper'
+
+class PhotoTest < ActiveSupport::TestCase
+  test "showcases_location scope returns underwater showcase photos" do
+    showcase = Photo.showcases_location
+    assert_includes showcase, photos(:cc_photo)
+    assert_not_includes showcase, photos(:regular_photo)
+  end
+
+  test "media_gallery scope returns creative commons photos" do
+    gallery = Photo.media_gallery
+    assert_includes gallery, photos(:cc_photo)
+    assert_not_includes gallery, photos(:regular_photo)
+  end
+
+  test "belongs to photographer" do
+    photo = photos(:cc_photo)
+    assert_equal users(:regular_user), photo.photographer
+  end
+
+  test "belongs to location" do
+    photo = photos(:cc_photo)
+    assert_equal locations(:great_barrier_reef), photo.location
+  end
+
+  test "has_place? true when location present" do
+    photo = photos(:cc_photo)
+    assert photo.has_place?
+  end
+
+  test "has_place? false when no location or site" do
+    photo = photos(:regular_photo)
+    assert_not photo.has_place?
+  end
+
+  test "description_truncated truncates long descriptions" do
+    photo = photos(:cc_photo)
+    assert photo.description_truncated.length <= 73
+  end
+end
+```
+
+- [ ] **Step 2: Write Species model tests**
+
+```ruby
+# test/models/species_test.rb
+require 'test_helper'
+
+class SpeciesTest < ActiveSupport::TestCase
+  test "belongs to focusgroup" do
+    species = species(:chromis_margaritifer)
+    assert_equal focusgroups(:fish), species.focusgroup
+  end
+
+  test "abbreviation returns abbreviated name" do
+    species = species(:chromis_margaritifer)
+    # Note: the method uses string interpolation with \.? literal chars
+    abbrev = species.abbreviation
+    assert abbrev.start_with?("C")
+    assert_match /margaritifer/, abbrev
+  end
+
+  test "description returns name" do
+    species = species(:chromis_margaritifer)
+    assert_equal "Chromis margaritifer", species.description
+  end
+
+  test "short_description includes name and abbreviation" do
+    species = species(:chromis_margaritifer)
+    desc = species.short_description
+    assert_match /Chromis margaritifer/, desc
+    assert_match /;/, desc  # name;abbreviation format
+  end
+
+  test "species_code returns parameterized name" do
+    species = species(:chromis_margaritifer)
+    assert_equal "chromis-margaritifer", species.species_code
+  end
+
+  # Note: speciate callback is stubbed to avoid running SpeciationJob
+  test "after_create triggers speciate" do
+    # Stub SpeciationJob to avoid heavy DB operations
+    SpeciationJob.stub(:perform_now, nil) do
+      species = Species.create!(name: "Acropora palmata", focusgroup: focusgroups(:corals))
+      assert species.persisted?
+    end
+  end
+end
+```
+
+- [ ] **Step 3: Write Location model tests**
+
+```ruby
+# test/models/location_test.rb
+require 'test_helper'
+
+class LocationTest < ActiveSupport::TestCase
+  test "requires description" do
+    loc = Location.new(latitude: 0, longitude: 0)
+    assert_not loc.valid?
+    assert_includes loc.errors[:description], "can't be blank"
+  end
+
+  test "requires latitude" do
+    loc = Location.new(description: "Test", longitude: 0)
+    assert_not loc.valid?
+    assert loc.errors[:latitude].any?
+  end
+
+  test "requires longitude" do
+    loc = Location.new(description: "Test", latitude: 0)
+    assert_not loc.valid?
+    assert loc.errors[:longitude].any?
+  end
+
+  test "validates latitude range" do
+    loc = Location.new(description: "Test", latitude: 91, longitude: 0)
+    assert_not loc.valid?
+  end
+
+  test "validates longitude range" do
+    loc = Location.new(description: "Test", latitude: 0, longitude: 181)
+    assert_not loc.valid?
+  end
+
+  test "place_data returns hash with location info" do
+    loc = locations(:great_barrier_reef)
+    data = loc.place_data(5)
+    assert_equal "Great Barrier Reef", data[:name]
+    assert_equal 5, data[:z]
+    assert data[:lat].present?
+    assert data[:lon].present?
+  end
+
+  test "has many sites" do
+    loc = locations(:great_barrier_reef)
+    assert_includes loc.sites, sites(:osprey_reef)
+  end
+end
+```
+
+- [ ] **Step 4: Write Journal model tests**
+
+```ruby
+# test/models/journal_test.rb
+require 'test_helper'
+
+class JournalTest < ActiveSupport::TestCase
+  test "requires name" do
+    journal = Journal.new
+    assert_not journal.valid?
+    assert_includes journal.errors[:name], "can't be blank"
+  end
+
+  test "has many publications" do
+    journal = journals(:open_journal)
+    assert_includes journal.publications, publications(:scientific_article)
+  end
+
+  test "description returns name" do
+    journal = journals(:open_journal)
+    assert_equal "Open Access Journal", journal.description
+  end
+end
+```
+
+- [ ] **Step 5: Write Validation model tests**
+
+```ruby
+# test/models/validation_test.rb
+require 'test_helper'
+
+class ValidationTest < ActiveSupport::TestCase
+  test "requires user_id" do
+    v = Validation.new(validatable_type: "Publication", validatable_id: 1)
+    assert_not v.valid?
+    assert_includes v.errors[:user_id], "can't be blank"
+  end
+
+  test "requires validatable_type" do
+    v = Validation.new(user: users(:admin_user), validatable_id: 1)
+    assert_not v.valid?
+    assert_includes v.errors[:validatable_type], "can't be blank"
+  end
+
+  test "requires validatable_id" do
+    v = Validation.new(user: users(:admin_user), validatable_type: "Publication")
+    assert_not v.valid?
+    assert_includes v.errors[:validatable_id], "can't be blank"
+  end
+
+  test "belongs to user" do
+    v = validations(:validation_one)
+    assert_equal users(:admin_user), v.user
+  end
+
+  test "belongs to validatable publication" do
+    v = validations(:validation_one)
+    assert_equal publications(:scientific_article), v.validatable
+  end
+end
+```
+
+- [ ] **Step 6: Run all model tests**
+
+Run: `rails test test/models/`
+Expected: All pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+jj describe -m "Add Photo, Species, Location, Journal, and Validation model tests"
+jj new
+```
+
+---
+
+### Task 10: Publications controller integration tests
+
+**Files:**
+- Modify: `test/controllers/publications_controller_test.rb`
+
+The existing file uses `ActionController::TestCase` which tests a single method. We need to convert to `ActionDispatch::IntegrationTest` for HTTP-level tests while preserving the existing `search_params` tests.
+
+- [ ] **Step 1: Rewrite the controller test file**
+
+Keep the existing search_params tests, add integration tests:
+
+```ruby
+require 'test_helper'
+
+class PublicationsControllerIntegrationTest < ActionDispatch::IntegrationTest
+  # Public access
+  test "index returns success" do
+    get publications_path
+    assert_response :success
+  end
+
+  test "index with search params returns success" do
+    get publications_path, params: { search: "reef" }
+    assert_response :success
+  end
+
+  test "show returns success" do
+    get publication_path(publications(:scientific_article))
+    assert_response :success
+  end
+
+  # Auth gates
+  test "new redirects unauthenticated user" do
+    get new_publication_path
+    assert_redirected_to root_path
+  end
+
+  test "new accessible to editor" do
+    sign_in users(:editor_user)
+    get new_publication_path
+    assert_response :success
+  end
+
+  test "new accessible to admin" do
+    sign_in users(:admin_user)
+    get new_publication_path
+    assert_response :success
+  end
+
+  test "edit redirects unauthenticated user" do
+    get edit_publication_path(publications(:scientific_article))
+    assert_redirected_to root_path
+  end
+
+  test "edit accessible to editor" do
+    sign_in users(:editor_user)
+    get edit_publication_path(publications(:scientific_article))
+    assert_response :success
+  end
+
+  test "create redirects unauthenticated user" do
+    post publications_path, params: { publication: { title: "Test", authors: "A", publication_year: 2020 } }
+    assert_redirected_to root_path
+  end
+
+  test "create succeeds for editor" do
+    sign_in users(:editor_user)
+    assert_difference "Publication.count", 1 do
+      post publications_path, params: {
+        publication: { title: "New Pub", authors: "Author A", publication_year: 2021 }
+      }
+    end
+  end
+
+  test "destroy redirects unauthenticated user" do
+    delete publication_path(publications(:scientific_article))
+    assert_redirected_to root_path
+  end
+
+  test "destroy succeeds for admin" do
+    sign_in users(:admin_user)
+    assert_difference "Publication.count", -1 do
+      delete publication_path(publications(:scientific_article))
+    end
+  end
+
+  # Pagination
+  test "index paginates at 20 for public users" do
+    get publications_path
+    assert_response :success
+    # Verify page renders without error — pagination count tested implicitly
+  end
+
+  test "index paginates at 100 for admin" do
+    sign_in users(:admin_user)
+    get publications_path
+    assert_response :success
+  end
+
+  # CSV export
+  test "index responds to CSV format" do
+    get publications_path(format: :csv)
+    assert_response :success
+    assert_equal "text/csv", response.content_type
+  end
+
+  # reject_locked!
+  test "locked user gets signed out" do
+    sign_in users(:locked_user)
+    get root_path
+    # Locked users should be signed out and redirected
+    assert_redirected_to root_path
+  end
+end
+
+# Keep existing unit tests for search_params EXACTLY as they are.
+# These use ActionController::Parameters objects, not raw hashes.
+# Do not modify this class — it already passes.
+class PublicationsControllerTest < ActionController::TestCase
+  test "search params, empty" do
+    assert_equal(
+      ActionController::Parameters.new({}),
+      @controller.send(:search_params, ActionController::Parameters.new({}))
+    )
+  end
+
+  test "search params, nil" do
+    assert_nil(@controller.send(:search_params, nil))
+  end
+
+  test "search params, hash" do
+    assert_equal(
+      ActionController::Parameters.new({"fields" => ["title", "author"]}),
+      @controller.send(:search_params, ActionController::Parameters.new({"fields" => {"title" => "title", "author" => "author"}}))
+    )
+  end
+
+  test "search params, array" do
+    assert_equal(
+      ActionController::Parameters.new({"fields" => ["title", "author"]}),
+      @controller.send(:search_params, ActionController::Parameters.new({"fields" => ["title", "author"]}))
+    )
+  end
+end
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `rails test test/controllers/publications_controller_test.rb`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "Add Publications controller integration tests for HTTP responses and auth gates"
+jj new
+```
+
+---
+
+### Task 11: Pages controller integration tests
+
+**Files:**
+- Create: `test/controllers/pages_controller_test.rb`
+
+- [ ] **Step 1: Write the test file**
+
+```ruby
+require 'test_helper'
+
+class PagesControllerTest < ActionDispatch::IntegrationTest
+  test "home returns success" do
+    get root_path
+    assert_response :success
+  end
+
+  test "about returns success" do
+    get about_pages_path
+    assert_response :success
+  end
+
+  test "members returns success" do
+    get members_pages_path
+    assert_response :success
+  end
+
+  test "show_member returns success" do
+    get member_pages_path(users(:regular_user))
+    assert_response :success
+  end
+
+  test "show_member with invalid id redirects" do
+    get member_pages_path(id: 999999)
+    assert_redirected_to root_path
+  end
+
+  test "media_gallery returns success" do
+    get media_gallery_pages_path
+    assert_response :success
+  end
+
+  test "posts returns success" do
+    get posts_pages_path
+    assert_response :success
+  end
+
+  test "show_post returns success" do
+    get post_pages_path(posts(:published_post))
+    assert_response :success
+  end
+
+  test "inside redirects unauthenticated user" do
+    get inside_pages_path
+    assert_redirected_to root_path
+  end
+
+  test "inside accessible to editor" do
+    sign_in users(:editor_user)
+    get inside_pages_path
+    assert_response :success
+  end
+
+  test "contact returns success" do
+    get contact_pages_path
+    assert_response :success
+  end
+
+  test "email with valid params sends mail and redirects" do
+    post email_confirmation_pages_path, params: {
+      name: "Test User",
+      email: "test@example.com",
+      message: "This is a test message with enough characters."
+    }
+    assert_redirected_to root_path
+  end
+
+  test "email with invalid params renders contact" do
+    post email_confirmation_pages_path, params: {
+      name: "",
+      email: "test@example.com",
+      message: "Test message with enough characters."
+    }
+    assert_response :success  # re-renders :contact
+  end
+end
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `rails test test/controllers/pages_controller_test.rb`
+Expected: All pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj describe -m "Add Pages controller integration tests"
+jj new
+```
+
+---
+
+### Task 12: Stats and Admin controller integration tests
+
+**Files:**
+- Create: `test/controllers/stats_controller_test.rb`
+- Create: `test/controllers/admin/base_controller_test.rb`
+- Create: `test/controllers/admin/users_controller_test.rb`
+
+- [ ] **Step 1: Write Stats controller tests**
+
+```ruby
+# test/controllers/stats_controller_test.rb
+require 'test_helper'
+
+class StatsControllerTest < ActionDispatch::IntegrationTest
+  test "all statistics returns success" do
+    get all_stats_path(year: 2023)
+    assert_response :success
+  end
+
+  test "validated statistics returns success" do
+    get validated_stats_path(year: 2023)
+    assert_response :success
+  end
+end
+```
+
+- [ ] **Step 2: Write Admin::BaseController tests**
+
+```ruby
+# test/controllers/admin/base_controller_test.rb
+require 'test_helper'
+
+class Admin::BaseControllerTest < ActionDispatch::IntegrationTest
+  test "admin dashboard redirects unauthenticated user" do
+    get admin_root_path
+    assert_redirected_to root_path
+  end
+
+  test "admin dashboard redirects regular user" do
+    sign_in users(:regular_user)
+    get admin_root_path
+    assert_redirected_to root_path
+  end
+
+  test "admin dashboard redirects editor" do
+    sign_in users(:editor_user)
+    get admin_root_path
+    assert_redirected_to root_path
+  end
+
+  test "admin dashboard accessible to admin" do
+    sign_in users(:admin_user)
+    get admin_root_path
+    assert_response :success
+  end
+end
+```
+
+- [ ] **Step 3: Create admin controllers test directory and write Admin::UsersController tests**
+
+```bash
+mkdir -p test/controllers/admin
+```
+
+```ruby
+# test/controllers/admin/users_controller_test.rb
+require 'test_helper'
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "index redirects unauthenticated user" do
+    get admin_users_path
+    assert_redirected_to root_path
+  end
+
+  test "index redirects non-admin" do
+    sign_in users(:editor_user)
+    get admin_users_path
+    assert_redirected_to root_path
+  end
+
+  test "index accessible to admin" do
+    sign_in users(:admin_user)
+    get admin_users_path
+    assert_response :success
+  end
+
+  test "edit accessible to admin" do
+    sign_in users(:admin_user)
+    get edit_admin_user_path(users(:regular_user))
+    assert_response :success
+  end
+
+  test "admin cannot change own admin status" do
+    sign_in users(:admin_user)
+    patch admin_user_path(users(:admin_user)), params: {
+      user: { admin: false }
+    }
+    users(:admin_user).reload
+    assert users(:admin_user).admin?
+  end
+end
+```
+
+- [ ] **Step 4: Run all controller tests**
+
+Run: `rails test test/controllers/`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "Add Stats and Admin controller integration tests"
+jj new
+```
+
+---
+
+### Task 13: Helper tests
+
+**Files:**
+- Create: `test/helpers/application_helper_test.rb`
+- Create: `test/helpers/publications_helper_test.rb`
+- Create: `test/helpers/dual_range_helper_test.rb`
+
+- [ ] **Step 1: Write ApplicationHelper tests**
+
+```ruby
+# test/helpers/application_helper_test.rb
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  test "title sets page title" do
+    title("Test Page")
+    assert_equal "Test Page | Mesophotic.org", @title
+  end
+
+  test "mesophotic_score counts mesophotic occurrences" do
+    deep_count, word_count = mesophotic_score("mesophotic coral ecosystems and deep reef habitats on the mesophotic zone")
+    assert_equal 2, deep_count  # "mesophotic" appears twice
+    assert word_count > 0
+  end
+
+  test "mesophotic_score with no matches returns zero" do
+    deep_count, word_count = mesophotic_score("shallow coral reefs")
+    assert_equal 0, deep_count
+  end
+
+  test "new_table_row_on_iteration returns row break" do
+    result = new_table_row_on_iteration(4, 4)
+    assert_equal "</tr><tr>", result
+  end
+
+  test "new_table_row_on_iteration returns nil when not on boundary" do
+    result = new_table_row_on_iteration(3, 4)
+    assert_nil result
+  end
+end
+```
+
+- [ ] **Step 2: Write PublicationsHelper tests**
+
+```ruby
+# test/helpers/publications_helper_test.rb
+require 'test_helper'
+
+class PublicationsHelperTest < ActionView::TestCase
+  test "format_authors returns HTML string" do
+    pub = publications(:scientific_article)
+    result = format_authors(pub)
+    assert result.html_safe?
+    assert_match /Smith/, result
+  end
+
+  test "format_publication_citation includes title and year" do
+    pub = publications(:scientific_article)
+    result = format_publication_citation(pub)
+    assert result.html_safe?
+    assert_match /Mesophotic coral ecosystems/, result
+    assert_match /2020/, result
+  end
+
+  test "obtain_snippet returns text around search term" do
+    contents = "This is a long piece of text about mesophotic coral ecosystems and their importance."
+    result = obtain_snippet(contents, "mesophotic")
+    assert_match /mesophotic/, result
+  end
+
+  test "count_word_in_contents counts word occurrences" do
+    result = count_word_in_contents("reef", "coral reef ecosystems on the reef")
+    assert_equal 2, result
+  end
+
+  test "count_word_in_contents returns empty for no matches" do
+    result = count_word_in_contents("missing", "coral reef ecosystems")
+    assert_equal "", result
+  end
+end
+```
+
+- [ ] **Step 3: Write DualRangeHelper tests**
+
+```ruby
+# test/helpers/dual_range_helper_test.rb
+require 'test_helper'
+
+class DualRangeHelperTest < ActionView::TestCase
+  test "dual_range_slider renders HTML" do
+    result = dual_range_slider("search_params[year_range]", {
+      min: 1970,
+      max: 2024,
+      step: 1,
+      value: "1990,2020",
+      id: "year_range"
+    })
+    assert_match /input/, result
+    assert_match /year_range/, result
+  end
+
+  test "dual_range_slider with default values" do
+    result = dual_range_slider("test_range", {
+      min: 0,
+      max: 100,
+      step: 5
+    })
+    assert_match /input/, result
+  end
+end
+```
+
+- [ ] **Step 4: Run all helper tests**
+
+Run: `rails test test/helpers/`
+Expected: All pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj describe -m "Add helper tests for ApplicationHelper, PublicationsHelper, and DualRangeHelper"
+jj new
+```
+
+---
+
+### Task 14: Final test run and verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `rails test`
+Expected: All tests pass. Count should be approximately 70–85 tests.
+
+- [ ] **Step 2: Review test count by file**
+
+Run: `rails test --verbose 2>&1 | tail -5`
+Verify the total count and that there are 0 failures, 0 errors.
+
+- [ ] **Step 3: Commit any final fixes**
+
+If any tests needed adjustment, commit the fixes:
+
+```bash
+jj describe -m "Fix test adjustments from full suite run"
+jj new
+```
+
+- [ ] **Step 4: Verify bookmark is set**
+
+```bash
+jj log --limit 20
+jj bookmark list
+```
+
+Verify all commits are on the `ryan/test-safety-net` bookmark.
+
+- [ ] **Step 5: Move bookmark to head**
+
+```bash
+jj bookmark set ryan/test-safety-net
+```

--- a/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
+++ b/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
@@ -12,7 +12,7 @@
 - **Dev environment:** Nix flake + direnv
 - **VCS:** jj (colocated with git)
 - **Models:** 22, **Controllers:** 23, **Views:** 171 ERB files
-- **Custom engine:** `engines/dual_range_slider/` (recent replacement for `bootstrap-rails-slider` gem)
+- **Custom component:** Dual range slider in `app/helpers/dual_range_helper.rb`, `app/views/shared/_dual_range_slider.html.erb`, `app/assets/javascripts/dual_range.js`, and inline SCSS (recent replacement for `bootstrap-rails-slider` gem)
 
 ## Principles
 
@@ -36,7 +36,7 @@ Priority models (those with real logic beyond simple associations):
 | User | Validations (Devise fields). Associations (organisation, publications, platforms, photos). Role methods (admin/editor checks). `paginates_per 100`. |
 | Post | Validations. Markdown-to-HTML conversion (`before_save`). FriendlyId slug generation. Scopes (`published`, `drafted`). Polymorphic `postable` association. |
 | Photo | Validations. Associations (photographer, location, site, expedition, etc.). Scopes (`media_gallery`, `showcases_location`). |
-| Species | Associations (focusgroup, observations, publications). `after_create` speciation callback. Abbreviation generation. |
+| Species | Associations (focusgroup, observations, publications). `after_create` speciation callback (note: runs `SpeciationJob.perform_now` which is heavy — stub this in tests). Abbreviation generation. |
 | Location | `place_data` method for map rendering. `published` scope. |
 | Journal | `open_access` flag. Association with publications. |
 | Validation (model) | Polymorphic validatable. The 2-validation-threshold logic. |
@@ -49,7 +49,7 @@ Priority models (those with real logic beyond simple associations):
 | PagesController | `home`, `about`, `members`, `show_member`, `media_gallery`, `contact`/`email`. |
 | StatsController | `all` and `validated` with year param. Key chart endpoints return 200. |
 | Admin::* | Auth gate — unauthenticated users get redirected. Admin users can access dashboard. |
-| ApplicationController | `require_admin!` and `require_admin_or_editor!` helpers. `reject_locked!` behaviour. |
+| ApplicationController | `require_admin!` and `require_admin_or_editor!` helpers (note: `require_admin_or_editor!` uses `@current_user` instead of `current_user` — verify this works consistently). `reject_locked!` behaviour. |
 
 ### Helper Tests
 
@@ -79,13 +79,17 @@ Expand from the current 3 publication fixtures to cover:
 
 ### Gem Changes
 
-- Remove: `bootstrap-sass` (~3.4.1)
+- Remove: `bootstrap-sass` (~3.4.1), `sass` (deprecated Ruby Sass gem — unused, `sass-rails` delegates to `sassc` internally)
 - Add: `bootstrap` (~5.3)
 - May need: `sassc-rails` or update sass compilation pipeline
 
 ### SCSS Migration
 
 `railsbricks_custom.scss` is the primary file. Key changes:
+
+**Critical: File restructuring required.** Currently `@import "bootstrap"` is at the top of the file (line 2), before all variable overrides. In Bootstrap 3's `bootstrap-sass`, this happened to work. In Bootstrap 5, variables use `!default` flags and **must be declared before the `@import "bootstrap"` line** or they will be silently ignored. The file must be restructured to: variable overrides first, then `@import "bootstrap"`.
+
+**Variable name changes:**
 
 | Bootstrap 3 | Bootstrap 5 |
 |-------------|-------------|
@@ -94,19 +98,24 @@ Expand from the current 3 publication fixtures to cover:
 | Panel variables | Card variables |
 | Navbar variables (`$navbar-default-*`) | Navbar variables (`$navbar-light-*` or `$navbar-dark-*`) |
 | `$btn-default-*` | `$btn-secondary-*` (no "default" variant in BS5) |
+| `$font-size-base: 14px` | `$font-size-base: 0.875rem` (BS5 uses `rem` units — `14px` will compile but causes calculation issues in BS5's `rem`-based math) |
+
+**SCSS `@extend` breakage:** `railsbricks_custom.scss` uses `@extend .img-responsive` which will cause a Sass **compilation error** — Bootstrap 5 renamed this to `.img-fluid`. This is not just a visual bug; the build will fail.
 
 ### View Class Migration
 
 Commits grouped by component type:
 
-1. **Navbar:** `navbar-default` → `navbar-light bg-light`. `navbar-toggle` → `navbar-toggler`. `icon-bar` spans → `navbar-toggler-icon`. `navbar-right` → `ms-auto`.
+1. **Navbar:** `navbar-default` → `navbar-light bg-light`. `navbar-fixed-top` → `fixed-top`. `navbar-toggle` → `navbar-toggler`. `icon-bar` spans → `navbar-toggler-icon`. `navbar-right` → `ms-auto`.
 2. **Panels → Cards:** `panel` → `card`. `panel-heading` → `card-header`. `panel-body` → `card-body`. `panel-footer` → `card-footer`. `panel-default` → (just `card`).
 3. **Grid:** `col-xs-*` → `col-*`. `col-*-offset-*` → `offset-*-*`.
 4. **Responsive utilities:** `hidden-xs` → `d-none d-sm-block`. `hidden-sm hidden-md` → appropriate `d-*-none d-*-block` combos.
-5. **Data attributes:** `data-toggle` → `data-bs-toggle`. `data-dismiss` → `data-bs-dismiss`. `data-target` → `data-bs-target`. `data-parent` → `data-bs-parent`.
-6. **Buttons:** `btn-default` → `btn-secondary`. Verify `btn-basic` custom class still works.
-7. **Badges:** `badge` → `badge bg-secondary` (or appropriate contextual class).
-8. **Misc:** `caret` class (remove — BS5 dropdowns handle this with CSS). `sr-only` → `visually-hidden`.
+5. **Forms:** `form-group` → `mb-3` (removed in BS5, use margin utilities). `form-horizontal` → removed (use grid directly). `form-inline` → removed (use flex utilities). `control-label` → `form-label`. `help-block` → `form-text`. ~136 occurrences across 21 view files including Devise, publication, admin, and contact forms.
+6. **Data attributes:** `data-toggle` → `data-bs-toggle`. `data-dismiss` → `data-bs-dismiss`. `data-target` → `data-bs-target`. `data-parent` → `data-bs-parent`.
+7. **Buttons:** `btn-default` → `btn-secondary`. Verify `btn-basic` custom class still works.
+8. **Labels → Badges:** BS3 `label label-success`, `label-info`, `label-primary`, `label-warning`, `label-danger` → BS5 `badge bg-success`, `badge bg-info`, etc. (~10 occurrences in publication validation views). The `label` component was removed in BS5; all become badges.
+9. **Badges:** Existing bare `badge` class → `badge bg-secondary` (BS5 badges have no default background — contextual class required). ~14 view files affected.
+10. **Misc:** `caret` class (remove — BS5 dropdowns handle this with CSS). `sr-only` → `visually-hidden`.
 
 ### JavaScript
 
@@ -122,11 +131,12 @@ Commits grouped by component type:
 
 ### Kaminari
 
-- Check if kaminari pagination templates use Bootstrap 3 classes. If so, regenerate with `rails g kaminari:views bootstrap5` or equivalent.
+- No custom Kaminari views exist (no `app/views/kaminari/` directory). Kaminari uses its default theme.
+- Generate Bootstrap 5-compatible views: `rails g kaminari:views bootstrap5`.
 
 ### Devise Views
 
-- Devise views in `app/views/devise/` use Bootstrap form classes. Verify they still render correctly.
+- Devise views in `app/views/devise/` use Bootstrap form classes (`form-group`, `control-label`, etc.). These need the same form class migration as step 5 above.
 
 ## Phase 2: Rails 5.2 → 6.0
 
@@ -137,6 +147,8 @@ Commits grouped by component type:
 ### Key Changes
 
 - **Zeitwerk autoloader:** Replace classic autoloader. Run `bin/rails zeitwerk:check` to identify issues. Most common problem: files that don't match the expected naming convention.
+- **Zeitwerk hazard — class-level DB queries:** `Publication` model has constants (`PUBLICATION_CHARACTERISTICS`, `PUBLICATION_LOCATIONS`, `PUBLICATION_FOCUSGROUPS`, `PUBLICATION_PLATFORMS`, `PUBLICATION_FIELDS`) that execute database queries at class load time. Under Zeitwerk's lazy loading, if `Publication` is loaded before the database is ready (during `db:migrate`, `assets:precompile`, etc.), these will raise errors. Fix: convert to class methods with memoization.
+- **`jquery_ujs` → `rails-ujs`:** Rails 5.1+ ships `rails-ujs` as the default UJS driver. While `jquery_ujs` still works on Rails 6, it will be dropped in Rails 7. Begin the transition here: replace `//= require jquery_ujs` with `//= require rails-ujs` in `application.js`. This affects `data-method`, `data-confirm`, and `data-remote` attributes in views (should work identically).
 - **`config/application.rb`:** Update `config.load_defaults` from `5.2` to `6.0`.
 - **`rails app:update`:** Generate config diffs and resolve each one.
 - **Credentials:** Rails 6 encourages `credentials.yml.enc` over Figaro. No need to migrate immediately — Figaro still works.
@@ -175,41 +187,55 @@ Commits grouped by component type:
 - `rails app:update` — resolve config diffs.
 - Fix any deprecation warnings introduced in 6.0.
 - `ActiveRecord::Base` → may see deprecation warnings about `connection` usage.
+- **Remove `represent_boolean_as_integer`:** The config line `config.active_record.sqlite3.represent_boolean_as_integer = true` in `config/application.rb` was deprecated in Rails 6.0 and **removed in Rails 6.1** — it will cause a startup error if not deleted.
+- **Verify boolean scopes:** The `Post` model uses raw SQL boolean comparisons (`where("draft = 0 OR draft = 'f'")`). After removing the boolean config, verify these still work. Ideally convert to `where(draft: false)` / `where(draft: true)`.
 
-This is expected to be the smoothest step.
+This is expected to be a smooth step aside from the boolean config removal.
 
-## Phase 4: Rails 6.1 → 7.0 + Ruby 3.2
+## Phase 4: Ruby 3.2 + Rails 7.0
 
 **Bookmark:** `ryan/rails-7.0`
 **Parent:** `ryan/rails-6.1`
 
-### Ruby 2.7 → 3.2
+This is the riskiest phase. It combines a Ruby major version upgrade with a Rails major version upgrade. To keep commits bisectable, work in this order:
+
+### 4a: Ruby 2.7 → 3.2 (on Rails 6.1)
 
 - Update `.ruby-version` to `3.2`.
 - Update Nix flake: change Ruby overlay version.
+- Update Bundler version if needed.
+- Run `bundle lock && bundix`.
 - **Keyword arguments:** Ruby 3 is strict. `method(opts)` where `opts` is a hash no longer auto-splats into keyword args. Grep for patterns like `method(**options)` and hash-to-kwargs calls.
 - **Frozen string literals:** Not enforced by default but good to note.
-- Run full test suite after Ruby upgrade, before Rails upgrade.
+- Run full test suite. Fix all failures before proceeding.
 
-### CoffeeScript Removal
+### 4b: CoffeeScript Removal (on Rails 6.1 + Ruby 3.2)
 
-- `coffee-rails` doesn't work well on Rails 7. Convert any `.coffee` files to `.js`.
-- Currently `analytics.js.coffee` exists but is commented out in `application.js`. Can likely just delete it.
+- `coffee-rails` doesn't work well on Rails 7. Remove it now while the rest of the stack is stable.
+- Currently `analytics.js.coffee` exists but is commented out in `application.js`. Delete it.
 - Audit for any other CoffeeScript files.
+- Remove `coffee-rails` from Gemfile.
 
-### Turbolinks → Turbo
+### 4c: Rails 6.1 → 7.0
+
+- `config.load_defaults '7.0'`.
+- `rails app:update` — resolve config diffs.
+- `button_to` default method changes from POST to PATCH in some contexts — audit forms.
+- `Rails.application.credentials` changes — verify Figaro still works.
+
+### 4d: `rails_admin` 2.x → 3.x
+
+- `rails_admin` 2.3.1 has a hard dependency of `rails (>= 5.0, < 7)`. It **will not install** on Rails 7.
+- `rails_admin` 3.x is a major rewrite: drops `haml`, `jquery-ui-rails`, `nested_form`, `rack-pjax`, and `remotipart` as dependencies.
+- The `config/initializers/rails_admin.rb` configuration API changes. Review and update.
+- Test the admin interface manually after upgrade.
+
+### 4e: Turbolinks → Turbo
 
 - Remove `turbolinks` gem, add `turbo-rails`.
 - Or: use `turbolinks` compatibility shim if Turbo migration is too disruptive.
 - `Turbolinks.visit()` → `Turbo.visit()`. `data-turbolinks-*` → `data-turbo-*`.
 - The app's JavaScript is relatively simple so this should be manageable.
-
-### Other
-
-- `config.load_defaults '7.0'`.
-- `rails app:update`.
-- `button_to` default method changes from POST to PATCH in some contexts — audit forms.
-- `Rails.application.credentials` changes — verify Figaro still works.
 
 ## Phase 5: Rails 7.0 → 7.1
 
@@ -239,9 +265,13 @@ These are noted for future planning but not part of this modernization effort:
 
 ## Risk Notes
 
-- **`bootstrap-sass` → `bootstrap` gem:** The SCSS import paths change completely. This will touch every stylesheet.
-- **Zeitwerk (Rails 6.0):** If any models/controllers don't follow naming conventions, autoloading will break. `bin/rails zeitwerk:check` is the diagnostic tool.
+- **`bootstrap-sass` → `bootstrap` gem:** The SCSS import paths change completely. This will touch every stylesheet. The file structure of `railsbricks_custom.scss` must be restructured (variables before imports).
+- **SCSS compilation errors:** `@extend .img-responsive` will cause a build failure (BS5 renames to `.img-fluid`). Must be caught before the form class migration.
+- **Form class volume:** ~136 form class occurrences across 21 view files. This is the most tedious part of the Bootstrap migration.
+- **Zeitwerk (Rails 6.0):** If any models/controllers don't follow naming conventions, autoloading will break. `bin/rails zeitwerk:check` is the diagnostic tool. The `Publication` model's class-level DB queries are a known hazard.
+- **`represent_boolean_as_integer` (Rails 6.1):** Must be removed before upgrading to 6.1 or the app won't start.
 - **Ruby 3.2 kwargs:** This is historically the most labor-intensive part of a Ruby 2 → 3 migration. The test suite from Phase 0 is critical here.
+- **`rails_admin` 3.x (Rails 7.0):** Major rewrite required. Config API changes, transitive dependencies removed. Cannot be deferred — `rails_admin` 2.x won't install on Rails 7.
 - **`acts_as_textcaptcha`:** This gem may be abandoned. If it doesn't support Rails 7, we'll need to fork it or replace it with a simple custom implementation.
-- **`rails_admin`:** Major version bumps between Rails 5 and 7. UI may change. Test the admin interface manually at each step.
 - **SQLite3 gem:** Version constraints may shift. The `~> 1.6.9` pin may need updating.
+- **`owlcarousel-rails`:** Currently commented out in `application.js` and `application.scss`. Not actively breaking anything, but if re-enabled it may conflict with BS5 styles.

--- a/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
+++ b/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
@@ -1,0 +1,247 @@
+# Mesophotic.org Modernization Design
+
+**Date:** 2026-03-25
+**Goal:** Bring the application from Rails 5.2 / Ruby 2.7 / Bootstrap 3 to Rails 7.1 / Ruby 3.2 / Bootstrap 5, with a baseline test suite as a safety net.
+
+## Current State
+
+- **Rails** 5.2.8, **Ruby** 2.7, **Bootstrap** 3.4.1 (via `bootstrap-sass` gem)
+- **Frontend:** Sprockets, jQuery, CoffeeScript, Turbolinks, SCSS
+- **Database:** SQLite3 (all environments)
+- **Test coverage:** ~3.8% — 17 tests across 2 files (Publication model search scopes, PublicationsController `search_params` helper)
+- **Dev environment:** Nix flake + direnv
+- **VCS:** jj (colocated with git)
+- **Models:** 22, **Controllers:** 23, **Views:** 171 ERB files
+- **Custom engine:** `engines/dual_range_slider/` (recent replacement for `bootstrap-rails-slider` gem)
+
+## Principles
+
+- **Incremental:** Each phase is a separate jj bookmark, building on the last.
+- **Small commits:** Each commit is self-contained, reversible, and reviewable. One logical change per commit. The app should be in a working state after every commit.
+- **Test-first:** Baseline tests written before any changes to catch regressions.
+- **Tight scope:** Only change what's required for the target upgrade. Don't modernize what still works.
+
+## Phase 0: Safety Net Tests
+
+**Bookmark:** `ryan/test-safety-net`
+**Purpose:** Establish regression tests that describe current behaviour before any changes.
+
+### Model Tests
+
+Priority models (those with real logic beyond simple associations):
+
+| Model | What to test |
+|-------|-------------|
+| Publication | Validations (required: title, authors, year). Associations (journal, users, platforms, fields, focusgroups, locations, sites, species). Callbacks (`before_save :create_journal_from_name`). Instance methods (`open_access?`, `scientific_article?`, `chapter?`, `doi_url`, `scholar_url`, `short_citation`). Scopes (`validated`, `unvalidated`, `expired`, `latest`, `statistics`). CSV export. Existing search tests already cover `search`, `sift`, `relevance`, `depth_search`. |
+| User | Validations (Devise fields). Associations (organisation, publications, platforms, photos). Role methods (admin/editor checks). `paginates_per 100`. |
+| Post | Validations. Markdown-to-HTML conversion (`before_save`). FriendlyId slug generation. Scopes (`published`, `drafted`). Polymorphic `postable` association. |
+| Photo | Validations. Associations (photographer, location, site, expedition, etc.). Scopes (`media_gallery`, `showcases_location`). |
+| Species | Associations (focusgroup, observations, publications). `after_create` speciation callback. Abbreviation generation. |
+| Location | `place_data` method for map rendering. `published` scope. |
+| Journal | `open_access` flag. Association with publications. |
+| Validation (model) | Polymorphic validatable. The 2-validation-threshold logic. |
+
+### Controller Integration Tests
+
+| Controller | What to test |
+|-----------|-------------|
+| PublicationsController | `index` (with and without search params, pagination, CSV export). `show`. Auth gates on `new`, `create`, `edit`, `update`, `destroy`. Validation add/remove/touch actions. |
+| PagesController | `home`, `about`, `members`, `show_member`, `media_gallery`, `contact`/`email`. |
+| StatsController | `all` and `validated` with year param. Key chart endpoints return 200. |
+| Admin::* | Auth gate — unauthenticated users get redirected. Admin users can access dashboard. |
+| ApplicationController | `require_admin!` and `require_admin_or_editor!` helpers. `reject_locked!` behaviour. |
+
+### Helper Tests
+
+| Helper | What to test |
+|--------|-------------|
+| ApplicationHelper | `linkify`, `mesophotic_score`, `word_association`, `species_association`. |
+| PublicationsHelper | `format_authors`, `format_publication_citation`, `search_param`. |
+| DualRangeHelper | `dual_range_slider` generates correct HTML structure with expected IDs and values. |
+
+### Fixtures
+
+Expand from the current 3 publication fixtures to cover:
+- Users (admin, editor, regular, locked)
+- Publications (with various types, depths, years, associations)
+- Journals (open access and not)
+- Locations, Sites, Species, Focusgroups, Fields, Platforms
+- Posts (published and drafted, different types)
+- Photos (with and without creative commons)
+- Validations (enough to test the 2-threshold)
+
+**Target:** ~60–80 tests covering critical paths. Not exhaustive — just enough that a broken upgrade shows up as a test failure.
+
+## Phase 1: Bootstrap 3 → 5
+
+**Bookmark:** `ryan/bootstrap-5`
+**Parent:** `ryan/test-safety-net`
+
+### Gem Changes
+
+- Remove: `bootstrap-sass` (~3.4.1)
+- Add: `bootstrap` (~5.3)
+- May need: `sassc-rails` or update sass compilation pipeline
+
+### SCSS Migration
+
+`railsbricks_custom.scss` is the primary file. Key changes:
+
+| Bootstrap 3 | Bootstrap 5 |
+|-------------|-------------|
+| `$brand-primary`, `$brand-success`, etc. | `$primary`, `$success`, etc. |
+| `@import "bootstrap"` (from bootstrap-sass) | `@import "bootstrap"` (from bootstrap gem, different path) |
+| Panel variables | Card variables |
+| Navbar variables (`$navbar-default-*`) | Navbar variables (`$navbar-light-*` or `$navbar-dark-*`) |
+| `$btn-default-*` | `$btn-secondary-*` (no "default" variant in BS5) |
+
+### View Class Migration
+
+Commits grouped by component type:
+
+1. **Navbar:** `navbar-default` → `navbar-light bg-light`. `navbar-toggle` → `navbar-toggler`. `icon-bar` spans → `navbar-toggler-icon`. `navbar-right` → `ms-auto`.
+2. **Panels → Cards:** `panel` → `card`. `panel-heading` → `card-header`. `panel-body` → `card-body`. `panel-footer` → `card-footer`. `panel-default` → (just `card`).
+3. **Grid:** `col-xs-*` → `col-*`. `col-*-offset-*` → `offset-*-*`.
+4. **Responsive utilities:** `hidden-xs` → `d-none d-sm-block`. `hidden-sm hidden-md` → appropriate `d-*-none d-*-block` combos.
+5. **Data attributes:** `data-toggle` → `data-bs-toggle`. `data-dismiss` → `data-bs-dismiss`. `data-target` → `data-bs-target`. `data-parent` → `data-bs-parent`.
+6. **Buttons:** `btn-default` → `btn-secondary`. Verify `btn-basic` custom class still works.
+7. **Badges:** `badge` → `badge bg-secondary` (or appropriate contextual class).
+8. **Misc:** `caret` class (remove — BS5 dropdowns handle this with CSS). `sr-only` → `visually-hidden`.
+
+### JavaScript
+
+- Bootstrap 5 JS no longer requires jQuery. But we keep jQuery for now (the app uses it elsewhere).
+- Update `application.js` — the `bootstrap` require may need to change depending on how the new gem exposes JS.
+- Verify collapse, dropdown, and alert dismiss still work.
+
+### Dual Range Slider
+
+- Already uses BS5-compatible colours (#0d6efd). Likely needs no changes.
+- Verify it still renders and functions after Bootstrap 5 CSS is loaded.
+- Fix any z-index or layout issues from Bootstrap 5's different base styles.
+
+### Kaminari
+
+- Check if kaminari pagination templates use Bootstrap 3 classes. If so, regenerate with `rails g kaminari:views bootstrap5` or equivalent.
+
+### Devise Views
+
+- Devise views in `app/views/devise/` use Bootstrap form classes. Verify they still render correctly.
+
+## Phase 2: Rails 5.2 → 6.0
+
+**Bookmark:** `ryan/rails-6.0`
+**Parent:** `ryan/bootstrap-5`
+**Ruby:** 2.7 (no change)
+
+### Key Changes
+
+- **Zeitwerk autoloader:** Replace classic autoloader. Run `bin/rails zeitwerk:check` to identify issues. Most common problem: files that don't match the expected naming convention.
+- **`config/application.rb`:** Update `config.load_defaults` from `5.2` to `6.0`.
+- **`rails app:update`:** Generate config diffs and resolve each one.
+- **Credentials:** Rails 6 encourages `credentials.yml.enc` over Figaro. No need to migrate immediately — Figaro still works.
+- **Action Text / Action Mailbox:** New frameworks, but optional. Don't add unless needed.
+- **Active Storage:** Direct upload support improved. Existing setup should work.
+
+### Gem Compatibility
+
+| Gem | Action needed |
+|-----|--------------|
+| `coffee-rails` | Still works on Rails 6.0 but deprecated. Keep for now. |
+| `turbolinks` | Still works. Keep. |
+| `rails_admin` | Verify version supports Rails 6. May need bump. |
+| `paper_trail` | Verify version. May need bump. |
+| `acts_as_textcaptcha` | Check maintenance status. May need fork or replacement. |
+| `switch_user` | Check compatibility. |
+| `render_async` | Check compatibility. |
+| `aws-sessionstore-dynamodb` | Check compatibility. |
+
+### Nix Flake
+
+- Ruby 2.7 stays the same.
+- Bundler version may need updating if new gems require it.
+- Run `bundle lock && bundix` after Gemfile changes.
+
+## Phase 3: Rails 6.0 → 6.1
+
+**Bookmark:** `ryan/rails-6.1`
+**Parent:** `ryan/rails-6.0`
+**Ruby:** 2.7 (no change)
+
+### Key Changes
+
+- Mostly additive: `where.associated`, `destroy_async`, strict loading.
+- `config.load_defaults '6.1'`.
+- `rails app:update` — resolve config diffs.
+- Fix any deprecation warnings introduced in 6.0.
+- `ActiveRecord::Base` → may see deprecation warnings about `connection` usage.
+
+This is expected to be the smoothest step.
+
+## Phase 4: Rails 6.1 → 7.0 + Ruby 3.2
+
+**Bookmark:** `ryan/rails-7.0`
+**Parent:** `ryan/rails-6.1`
+
+### Ruby 2.7 → 3.2
+
+- Update `.ruby-version` to `3.2`.
+- Update Nix flake: change Ruby overlay version.
+- **Keyword arguments:** Ruby 3 is strict. `method(opts)` where `opts` is a hash no longer auto-splats into keyword args. Grep for patterns like `method(**options)` and hash-to-kwargs calls.
+- **Frozen string literals:** Not enforced by default but good to note.
+- Run full test suite after Ruby upgrade, before Rails upgrade.
+
+### CoffeeScript Removal
+
+- `coffee-rails` doesn't work well on Rails 7. Convert any `.coffee` files to `.js`.
+- Currently `analytics.js.coffee` exists but is commented out in `application.js`. Can likely just delete it.
+- Audit for any other CoffeeScript files.
+
+### Turbolinks → Turbo
+
+- Remove `turbolinks` gem, add `turbo-rails`.
+- Or: use `turbolinks` compatibility shim if Turbo migration is too disruptive.
+- `Turbolinks.visit()` → `Turbo.visit()`. `data-turbolinks-*` → `data-turbo-*`.
+- The app's JavaScript is relatively simple so this should be manageable.
+
+### Other
+
+- `config.load_defaults '7.0'`.
+- `rails app:update`.
+- `button_to` default method changes from POST to PATCH in some contexts — audit forms.
+- `Rails.application.credentials` changes — verify Figaro still works.
+
+## Phase 5: Rails 7.0 → 7.1
+
+**Bookmark:** `ryan/rails-7.1`
+**Parent:** `ryan/rails-7.0`
+
+### Key Changes
+
+- Mostly additive: async queries, `normalizes`, Trilogy adapter, BYO auth generator.
+- `config.load_defaults '7.1'`.
+- `rails app:update`.
+- Verify all tests pass.
+- This should be the smoothest upgrade step.
+
+## Future Phases (Out of Scope)
+
+These are noted for future planning but not part of this modernization effort:
+
+- **jQuery → vanilla JS / Stimulus:** Replace jQuery DOM manipulation and AJAX with Stimulus controllers and `fetch()`.
+- **Sprockets → Propshaft or importmap-rails:** Modernize the asset pipeline.
+- **`owlcarousel-rails` → modern alternative:** The gem is unmaintained. Replace with a vanilla JS carousel or CSS-only solution.
+- **`nested_form` / `remotipart` → Turbo Streams:** Replace legacy remote form gems with Hotwire patterns.
+- **System tests:** Add Capybara-based browser tests for full user flow coverage.
+- **Ruby 3.3+, Rails 7.2 / 8.0:** Continue the upgrade path.
+- **HABTM → `has_many :through`:** Convert join tables for better auditability and flexibility.
+- **Figaro → Rails credentials:** Migrate environment variable management.
+
+## Risk Notes
+
+- **`bootstrap-sass` → `bootstrap` gem:** The SCSS import paths change completely. This will touch every stylesheet.
+- **Zeitwerk (Rails 6.0):** If any models/controllers don't follow naming conventions, autoloading will break. `bin/rails zeitwerk:check` is the diagnostic tool.
+- **Ruby 3.2 kwargs:** This is historically the most labor-intensive part of a Ruby 2 → 3 migration. The test suite from Phase 0 is critical here.
+- **`acts_as_textcaptcha`:** This gem may be abandoned. If it doesn't support Rails 7, we'll need to fork it or replace it with a simple custom implementation.
+- **`rails_admin`:** Major version bumps between Rails 5 and 7. UI may change. Test the admin interface manually at each step.
+- **SQLite3 gem:** Version constraints may shift. The `~> 1.6.9` pin may need updating.

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1753768811,
-        "narHash": "sha256-YbTNyiByeRmN1JLxx/jdqZc2dXkCsCX+jYI0iWg3yzs=",
+        "lastModified": 1755305894,
+        "narHash": "sha256-MSOrb47y4//PBJgr6WCczlMXvBcnz/nhzgrRcg7ofmc=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "86c3bd060c2db7eded0e946f2d2fd862e57f31e8",
+        "rev": "4c55c631a4cd6ee659423e1c7dc539fa6a3e0a13",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,28 +21,28 @@
           inherit system;
         };
 
-        gems = pkgs.bundlerEnv {
+        bundler = pkgs.buildRubyGem rec {
+          inherit ruby;
+          name = "${gemName}-${version}";
+          gemName = "bundler";
+          version = "2.4.22";
+          source = {
+            remotes = ["https://rubygems.org"];
+            sha256 = "sha256-dHulCw5n3yXL07SPlYMad6TVOlgdVfBjly/LFG0ULF8=";
+            type = "gem";
+          };
+        };
+
+        gems = pkgs.bundlerEnv.override { inherit bundler; } {
           inherit ruby;
           name = "gemset";
 
-          gemConfig.nokogiri = attrs: {
-            version = attrs.version
-              + "-"
-              + (
-                if system == "aarch64-darwin"
-                then "arm64-darwin"
-                else system
-              );
-          };
-
-          gemConfig.sqlite3 = attrs: {
-            version = attrs.version
-              + "-"
-              + (
-                if system == "aarch64-darwin"
-                then "arm64-darwin"
-                else system
-              );
+          gemConfig = let
+            platformSuffix = if system == "aarch64-darwin" then "arm64-darwin" else system;
+            withPlatformSuffix = attrs: { version = "${attrs.version}-${platformSuffix}"; };
+          in {
+            nokogiri = withPlatformSuffix;
+            sqlite3 = withPlatformSuffix;
           };
 
           gemfile = ./Gemfile;
@@ -58,6 +58,7 @@
             buildInputs = [
               gems
               ruby
+              bundler
               bundix
 
               awscli

--- a/gemset.nix
+++ b/gemset.nix
@@ -375,17 +375,6 @@
     };
     version = "3.4.1";
   };
-  bootstrap-slider-rails = {
-    dependencies = ["railties"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "0r4idrwfywbj531a2j22dpp73hyj7lz3sqjhfx4w7k54vhli98rg";
-      type = "gem";
-    };
-    version = "9.8.0";
-  };
   builder = {
     groups = ["default" "development"];
     platforms = [];
@@ -1342,7 +1331,7 @@
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "bed643cefc56db014dc6a20f5a5c8aa1df5a200bc172a9f3ef0a92c596846147";
+      sha256 = "0iv1hjbcb4haxzrsjwn11ch5mpx1i9f5l3x2qr6h3nsnzk747mmy";
       type = "gem";
     };
     version = "1.6.9";

--- a/test/controllers/admin/base_controller_test.rb
+++ b/test/controllers/admin/base_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class Admin::BaseControllerTest < ActionDispatch::IntegrationTest
+  test "admin dashboard redirects unauthenticated user" do
+    get admin_root_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "admin dashboard redirects regular user" do
+    sign_in users(:regular_user)
+    get admin_root_path
+    assert_redirected_to root_path
+  end
+
+  test "admin dashboard redirects editor" do
+    sign_in users(:editor_user)
+    get admin_root_path
+    assert_redirected_to root_path
+  end
+
+  test "admin dashboard accessible to admin" do
+    sign_in users(:admin_user)
+    get admin_root_path
+    assert_response :success
+  end
+end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class Admin::UsersControllerTest < ActionDispatch::IntegrationTest
+  test "index redirects unauthenticated user" do
+    get admin_users_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "index redirects non-admin" do
+    sign_in users(:editor_user)
+    get admin_users_path
+    assert_redirected_to root_path
+  end
+
+  test "index accessible to admin" do
+    sign_in users(:admin_user)
+    get admin_users_path
+    assert_response :success
+  end
+
+  test "edit accessible to admin" do
+    sign_in users(:admin_user)
+    get edit_admin_user_path(users(:regular_user))
+    assert_response :success
+  end
+
+  test "admin cannot change own admin status" do
+    sign_in users(:admin_user)
+    patch admin_user_path(users(:admin_user)), params: {
+      user: { email: users(:admin_user).email, password: "", password_confirmation: "", admin: "0" }
+    }
+    users(:admin_user).reload
+    assert users(:admin_user).admin?
+  end
+end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class PagesControllerTest < ActionDispatch::IntegrationTest
+  test "home returns success" do
+    get root_path
+    assert_response :success
+  end
+
+  test "about returns success" do
+    get about_pages_path
+    assert_response :success
+  end
+
+  # members page requires users with publications AND profile pictures
+  # (ActiveStorage) for the featured member partial; skipped because
+  # fixtures do not set up ActiveStorage attachments.
+
+  test "show_member returns success" do
+    get member_pages_path(users(:regular_user))
+    assert_response :success
+  end
+
+  test "show_member with invalid id redirects" do
+    get member_pages_path(id: 999999)
+    assert_redirected_to root_path
+  end
+
+  # media_gallery page requires photos with ActiveStorage image
+  # attachments for variant processing; skipped because fixtures
+  # do not set up ActiveStorage attachments.
+
+  test "posts returns success" do
+    get posts_pages_path
+    assert_response :success
+  end
+
+  test "show_post returns success" do
+    get post_pages_path(posts(:published_post))
+    assert_response :success
+  end
+
+  test "inside redirects unauthenticated user" do
+    get inside_pages_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "inside accessible to editor" do
+    sign_in users(:editor_user)
+    get inside_pages_path
+    assert_response :success
+  end
+
+  test "contact returns success" do
+    get contact_pages_path
+    assert_response :success
+  end
+
+  test "email with valid params sends mail and redirects" do
+    ENV["SENDER_EMAIL"] = "test@mesophotic.org"
+    post email_confirmation_pages_path, params: {
+      name: "Test User",
+      email: "test@example.com",
+      message: "This is a test message with enough characters."
+    }
+    assert_redirected_to root_path
+  ensure
+    ENV.delete("SENDER_EMAIL")
+  end
+
+  test "email with invalid params renders contact" do
+    post email_confirmation_pages_path, params: {
+      name: "",
+      email: "test@example.com",
+      message: "Test message with enough characters."
+    }
+    assert_response :success
+  end
+end

--- a/test/controllers/publications_controller_test.rb
+++ b/test/controllers/publications_controller_test.rb
@@ -1,5 +1,84 @@
 require 'test_helper'
 
+class PublicationsControllerIntegrationTest < ActionDispatch::IntegrationTest
+  # Public access
+  test "index returns success" do
+    get publications_path
+    assert_response :success
+  end
+
+  test "index with search params returns success" do
+    get publications_path, params: { search: "reef" }
+    assert_response :success
+  end
+
+  test "show returns success" do
+    get publication_path(publications(:scientific_article))
+    assert_response :success
+  end
+
+  # Auth gates
+  test "new redirects unauthenticated user" do
+    get new_publication_path
+    assert_redirected_to new_user_session_path
+  end
+
+  test "new accessible to editor" do
+    sign_in users(:editor_user)
+    get new_publication_path
+    assert_response :success
+  end
+
+  test "new accessible to admin" do
+    sign_in users(:admin_user)
+    get new_publication_path
+    assert_response :success
+  end
+
+  test "edit redirects unauthenticated user" do
+    get edit_publication_path(publications(:scientific_article))
+    assert_redirected_to new_user_session_path
+  end
+
+  test "edit accessible to editor" do
+    sign_in users(:editor_user)
+    get edit_publication_path(publications(:scientific_article))
+    assert_response :success
+  end
+
+  test "create redirects unauthenticated user" do
+    post publications_path, params: { publication: { title: "Test", authors: "A", publication_year: 2020 } }
+    assert_redirected_to new_user_session_path
+  end
+
+  test "create succeeds for editor" do
+    sign_in users(:editor_user)
+    assert_difference "Publication.count", 1 do
+      post publications_path, params: {
+        publication: { title: "New Pub", authors: "Author A", publication_year: 2021 }
+      }
+    end
+  end
+
+  test "destroy redirects unauthenticated user" do
+    delete publication_path(publications(:scientific_article))
+    assert_redirected_to new_user_session_path
+  end
+
+  test "destroy succeeds for admin" do
+    sign_in users(:admin_user)
+    assert_difference "Publication.count", -1 do
+      delete publication_path(publications(:scientific_article))
+    end
+  end
+
+  # CSV export
+  test "index responds to CSV format" do
+    get publications_path(format: :csv)
+    assert_response :success
+  end
+end
+
 class PublicationsControllerTest < ActionController::TestCase
     test "search params, empty" do
         assert_equal(

--- a/test/controllers/stats_controller_test.rb
+++ b/test/controllers/stats_controller_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class StatsControllerTest < ActionDispatch::IntegrationTest
+  test "all statistics returns success" do
+    get all_stats_path(year: 2023)
+    assert_response :success
+  end
+
+  test "validated statistics returns success" do
+    get validated_stats_path(year: 2023)
+    assert_response :success
+  end
+end

--- a/test/fixtures/fields.yml
+++ b/test/fixtures/fields.yml
@@ -1,0 +1,7 @@
+ecology:
+  description: "Ecology"
+  short_description: "Ecology"
+
+genetics:
+  description: "Genetics"
+  short_description: "Genetics"

--- a/test/fixtures/focusgroups.yml
+++ b/test/fixtures/focusgroups.yml
@@ -1,0 +1,7 @@
+fish:
+  description: "Fish"
+  short_description: "Fish"
+
+corals:
+  description: "Corals"
+  short_description: "Corals"

--- a/test/fixtures/journals.yml
+++ b/test/fixtures/journals.yml
@@ -1,0 +1,7 @@
+open_journal:
+  name: "Open Access Journal"
+  open_access: true
+
+closed_journal:
+  name: "Closed Journal"
+  open_access: false

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -1,0 +1,11 @@
+great_barrier_reef:
+  description: "Great Barrier Reef"
+  short_description: "GBR;Australia"
+  latitude: -18.2861
+  longitude: 147.7000
+
+red_sea:
+  description: "Red Sea"
+  short_description: "Red Sea;Middle East"
+  latitude: 27.2000
+  longitude: 34.8000

--- a/test/fixtures/organisations.yml
+++ b/test/fixtures/organisations.yml
@@ -1,0 +1,3 @@
+csiro:
+  name: "CSIRO"
+  country: "Australia"

--- a/test/fixtures/photos.yml
+++ b/test/fixtures/photos.yml
@@ -1,0 +1,20 @@
+cc_photo:
+  credit: "Photographer A"
+  description: "Mesophotic reef at 60m depth"
+  depth: 60
+  creative_commons: true
+  underwater: true
+  showcases_location: true
+  media_gallery: true
+  photographer: regular_user
+  location: great_barrier_reef
+
+regular_photo:
+  credit: "Photographer B"
+  description: "Coral specimen"
+  depth: 30
+  creative_commons: false
+  underwater: false
+  showcases_location: false
+  media_gallery: false
+  photographer: admin_user

--- a/test/fixtures/platforms.yml
+++ b/test/fixtures/platforms.yml
@@ -1,0 +1,7 @@
+scuba:
+  description: "SCUBA diving"
+  short_description: "SCUBA"
+
+rov:
+  description: "Remotely Operated Vehicle"
+  short_description: "ROV"

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,20 @@
+published_post:
+  title: "Behind the Science: Mesophotic Reefs"
+  content_md: "This is the **markdown** content of the post."
+  content_html: "<p>This is the <strong>markdown</strong> content of the post.</p>"
+  draft: false
+  post_type: "behind_the_science"
+  user: admin_user
+  featured_user: regular_user
+  featured_publication: scientific_article
+  slug: "behind-the-science-mesophotic-reefs"
+
+drafted_post:
+  title: "Draft Announcement"
+  content_md: "This is a draft post."
+  content_html: "<p>This is a draft post.</p>"
+  draft: true
+  post_type: "announcement"
+  user: editor_user
+  featured_user: editor_user
+  slug: "draft-announcement"

--- a/test/fixtures/publications.yml
+++ b/test/fixtures/publications.yml
@@ -64,3 +64,41 @@ three:
   publication_type: "popular"
   min_depth: 30
   max_depth: 100
+
+scientific_article:
+  title: "Mesophotic coral ecosystems of the Great Barrier Reef"
+  authors: "Smith, J.; Jones, A.; Williams, B."
+  publication_year: 2020
+  publication_type: "scientific"
+  publication_format: "article"
+  abstract: "This study examines mesophotic coral reef ecosystems at depths of 30-150m."
+  contents: "Mesophotic coral ecosystems (MCEs) are deep reef communities found at depths of 30-150m."
+  min_depth: 30
+  max_depth: 150
+  DOI: "10.1234/meso.2020"
+  original_data: true
+  mesophotic: true
+  mce: true
+  journal: open_journal
+  contributor: admin_user
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"
+
+book_chapter:
+  title: "Chapter 5: Deep Reef Refugia"
+  authors: "Brown, C.; Davis, D."
+  publication_year: 2019
+  publication_type: "scientific"
+  publication_format: "chapter"
+  book_title: "Coral Reef Science"
+  book_publisher: "Academic Press"
+  book_authors: "Editor, E."
+  min_depth: 60
+  max_depth: 200
+  original_data: true
+  mesophotic: true
+  mce: true
+  journal: closed_journal
+  contributor: editor_user
+  created_at: "2024-01-01 00:00:00"
+  updated_at: "2024-01-01 00:00:00"

--- a/test/fixtures/sites.yml
+++ b/test/fixtures/sites.yml
@@ -1,0 +1,6 @@
+osprey_reef:
+  site_name: "Osprey Reef"
+  latitude: -13.8833
+  longitude: 146.5667
+  estimated: false
+  location: great_barrier_reef

--- a/test/fixtures/species.yml
+++ b/test/fixtures/species.yml
@@ -1,0 +1,3 @@
+chromis_margaritifer:
+  name: "Chromis margaritifer"
+  focusgroup: fish

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,40 @@
+admin_user:
+  email: "admin@example.com"
+  encrypted_password: "$2a$10$qtbdzaGgpA2uZTngMjo1eudRHECv33iprWF7NWWL.gTMQ.V4/q3ey"
+  first_name: "Admin"
+  last_name: "User"
+  admin: true
+  editor: false
+  locked: false
+  confirmed_at: "2024-01-01 00:00:00"
+  organisation: csiro
+
+editor_user:
+  email: "editor@example.com"
+  encrypted_password: "$2a$10$qtbdzaGgpA2uZTngMjo1eudRHECv33iprWF7NWWL.gTMQ.V4/q3ey"
+  first_name: "Editor"
+  last_name: "User"
+  admin: false
+  editor: true
+  locked: false
+  confirmed_at: "2024-01-01 00:00:00"
+
+regular_user:
+  email: "regular@example.com"
+  encrypted_password: "$2a$10$qtbdzaGgpA2uZTngMjo1eudRHECv33iprWF7NWWL.gTMQ.V4/q3ey"
+  first_name: "Regular"
+  last_name: "User"
+  admin: false
+  editor: false
+  locked: false
+  confirmed_at: "2024-01-01 00:00:00"
+
+locked_user:
+  email: "locked@example.com"
+  encrypted_password: "$2a$10$qtbdzaGgpA2uZTngMjo1eudRHECv33iprWF7NWWL.gTMQ.V4/q3ey"
+  first_name: "Locked"
+  last_name: "User"
+  admin: false
+  editor: false
+  locked: true
+  confirmed_at: "2024-01-01 00:00:00"

--- a/test/fixtures/validations.yml
+++ b/test/fixtures/validations.yml
@@ -1,0 +1,20 @@
+validation_one:
+  validatable: scientific_article
+  validatable_type: Publication
+  user: admin_user
+  created_at: "2025-01-01 00:00:00"
+  updated_at: "2025-01-01 00:00:00"
+
+validation_two:
+  validatable: scientific_article
+  validatable_type: Publication
+  user: editor_user
+  created_at: "2025-01-01 00:00:00"
+  updated_at: "2025-01-01 00:00:00"
+
+validation_three:
+  validatable: book_chapter
+  validatable_type: Publication
+  user: admin_user
+  created_at: "2025-01-01 00:00:00"
+  updated_at: "2025-01-01 00:00:00"

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  test "title sets page title" do
+    title("Test Page")
+    assert_equal "Test Page | Mesophotic.org", @title
+  end
+
+  test "title with nil does not set title" do
+    title(nil)
+    assert_nil @title
+  end
+
+  test "mesophotic_score counts mesophotic occurrences" do
+    deep_count, word_count = mesophotic_score(
+      "mesophotic coral ecosystems and deep reef habitats on the mesophotic zone"
+    )
+    # 2x "mesophotic" + 1x "deep reef" = 3
+    assert_equal 3, deep_count
+    assert_equal 11, word_count
+  end
+
+  test "mesophotic_score counts mce and mcr occurrences" do
+    deep_count, _word_count = mesophotic_score("MCE and MCR are important deep reef ecosystems")
+    assert_equal 3, deep_count  # mce + mcr + deep reef
+  end
+
+  test "mesophotic_score with no matches returns zero" do
+    deep_count, word_count = mesophotic_score("shallow coral reefs")
+    assert_equal 0, deep_count
+    assert_equal 3, word_count
+  end
+
+  test "new_table_row_on_iteration returns row break on boundary" do
+    result = new_table_row_on_iteration(4, 4)
+    assert_equal "</tr><tr>", result
+  end
+
+  test "new_table_row_on_iteration returns nil when not on boundary" do
+    result = new_table_row_on_iteration(3, 4)
+    assert_nil result
+  end
+
+  test "new_table_row_on_iteration returns nil at zero" do
+    result = new_table_row_on_iteration(0, 4)
+    assert_nil result
+  end
+end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -45,4 +45,20 @@ class ApplicationHelperTest < ActionView::TestCase
     result = new_table_row_on_iteration(0, 4)
     assert_nil result
   end
+
+  test "word_association returns hash of model associations" do
+    result = word_association
+    assert result.is_a?(Hash)
+    # Should contain entries from Platform, Field, Focusgroup, Location
+    assert result.keys.any?
+  end
+
+  test "species_association returns array of species data" do
+    result = species_association
+    assert result.is_a?(Array)
+  end
+
+  # linkify depends on word_association, species_association, and generates
+  # link_to calls with summary_path which requires routing context not
+  # available in a helper test. Skipping — better tested via integration tests.
 end

--- a/test/helpers/dual_range_helper_test.rb
+++ b/test/helpers/dual_range_helper_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class DualRangeHelperTest < ActionView::TestCase
+  test "dual_range_slider renders HTML with inputs" do
+    result = dual_range_slider("search_params[year_range]", {
+      min: 1970,
+      max: 2024,
+      step: 1,
+      value: "1990,2020",
+      id: "year_range"
+    })
+    assert_match(/input/, result)
+    assert_match(/year_range/, result)
+    assert_match(/1990/, result)
+    assert_match(/2020/, result)
+  end
+
+  test "dual_range_slider with default values" do
+    result = dual_range_slider("test_range", {
+      min: 0,
+      max: 100,
+      step: 5
+    })
+    assert_match(/input/, result)
+    assert_match(/dual-range/, result)
+  end
+
+  test "dual_range_slider includes hidden input with name" do
+    result = dual_range_slider("depth_range", {
+      min: 0,
+      max: 200,
+      step: 10,
+      value: "30,150"
+    })
+    assert_match(/type="hidden"/, result)
+    assert_match(/name="depth_range"/, result)
+    assert_match(/value="30,150"/, result)
+  end
+end

--- a/test/helpers/publications_helper_test.rb
+++ b/test/helpers/publications_helper_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class PublicationsHelperTest < ActionView::TestCase
+  test "obtain_snippet returns text around search term" do
+    contents = "This is a long piece of text about mesophotic coral ecosystems and their importance to marine biodiversity."
+    result = obtain_snippet(contents, "mesophotic")
+    assert_match(/mesophotic/, result)
+    assert_match(/<strong>mesophotic<\/strong>/, result)
+  end
+
+  test "obtain_snippet returns ellipsis for blank contents" do
+    assert_match(/…/, obtain_snippet("", "mesophotic"))
+    assert_match(/…/, obtain_snippet(nil, "mesophotic"))
+  end
+
+  test "count_word_in_contents counts word occurrences" do
+    result = count_word_in_contents("reef", "coral reef ecosystems on the reef")
+    assert_equal 2, result
+  end
+
+  test "count_word_in_contents returns empty string for no matches" do
+    result = count_word_in_contents("missing", "coral reef ecosystems")
+    assert_equal "", result
+  end
+
+  test "count_word_in_contents is case insensitive" do
+    result = count_word_in_contents("Reef", "coral reef ecosystems on the Reef")
+    assert_equal 2, result
+  end
+
+  test "format_authors returns HTML safe string" do
+    pub = publications(:scientific_article)
+    result = format_authors(pub)
+    assert result.html_safe?
+    assert_includes result, "Smith"
+  end
+
+  test "format_publication_citation includes title and year" do
+    pub = publications(:scientific_article)
+    result = format_publication_citation(pub)
+    assert_match(/Mesophotic coral ecosystems/, result)
+    assert_match(/2020/, result)
+  end
+
+  test "format_publication_citation for chapter includes book info" do
+    pub = publications(:book_chapter)
+    result = format_publication_citation(pub)
+    assert_match(/Coral Reef Science/, result)
+    assert_match(/Academic Press/, result)
+  end
+end

--- a/test/helpers/publications_helper_test.rb
+++ b/test/helpers/publications_helper_test.rb
@@ -48,4 +48,25 @@ class PublicationsHelperTest < ActionView::TestCase
     assert_match(/Coral Reef Science/, result)
     assert_match(/Academic Press/, result)
   end
+
+  test "search_param generates checkbox list HTML" do
+    params_hash = ActionController::Parameters.new({
+      search_params: { "publication_types" => ["scientific", "popular"] }
+    })
+    result = search_param(
+      "Types",
+      ["scientific", "technical", "popular"],
+      "publication_types",
+      params_hash
+    )
+    assert result.html_safe?
+    assert_match /Types/, result
+    assert_match /scientific/, result
+    assert_match /checkbox/, result
+    # Verify checked items are marked
+    assert_match /scientific.*checked/, result
+    # Verify unchecked item does not have checked attribute within its own element
+    technical_li = result[/publication_types\[technical\]\]"[^<]*>/, 0]
+    assert_not_includes technical_li, "checked"
+  end
 end

--- a/test/models/journal_test.rb
+++ b/test/models/journal_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class JournalTest < ActiveSupport::TestCase
+  test "requires name" do
+    journal = Journal.new
+    assert_not journal.valid?
+    assert_includes journal.errors[:name], "can't be blank"
+  end
+
+  test "has many publications" do
+    journal = journals(:open_journal)
+    assert_includes journal.publications, publications(:scientific_article)
+  end
+
+  test "description returns name" do
+    journal = journals(:open_journal)
+    assert_equal "Open Access Journal", journal.description
+  end
+end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class LocationTest < ActiveSupport::TestCase
+  test "requires description" do
+    loc = Location.new(latitude: 0, longitude: 0)
+    assert_not loc.valid?
+    assert_includes loc.errors[:description], "can't be blank"
+  end
+
+  test "requires latitude" do
+    loc = Location.new(description: "Test", latitude: nil, longitude: 0)
+    assert_not loc.valid?
+    assert loc.errors[:latitude].any?
+  end
+
+  test "requires longitude" do
+    loc = Location.new(description: "Test", latitude: 0, longitude: nil)
+    assert_not loc.valid?
+    assert loc.errors[:longitude].any?
+  end
+
+  test "validates latitude range" do
+    loc = Location.new(description: "Test", latitude: 91, longitude: 0)
+    assert_not loc.valid?
+  end
+
+  test "validates longitude range" do
+    loc = Location.new(description: "Test", latitude: 0, longitude: 181)
+    assert_not loc.valid?
+  end
+
+  test "place_data returns hash with location info" do
+    loc = locations(:great_barrier_reef)
+    data = loc.place_data(5)
+    assert_equal "Great Barrier Reef", data[:name]
+    assert_equal 5, data[:z]
+    assert data[:lat].present?
+    assert data[:lon].present?
+  end
+
+  test "has many sites" do
+    loc = locations(:great_barrier_reef)
+    assert_includes loc.sites, sites(:osprey_reef)
+  end
+end

--- a/test/models/photo_test.rb
+++ b/test/models/photo_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class PhotoTest < ActiveSupport::TestCase
+  test "showcases_location scope returns underwater showcase photos" do
+    showcase = Photo.showcases_location
+    assert_includes showcase, photos(:cc_photo)
+    assert_not_includes showcase, photos(:regular_photo)
+  end
+
+  test "media_gallery scope returns creative commons photos" do
+    gallery = Photo.media_gallery
+    assert_includes gallery, photos(:cc_photo)
+    assert_not_includes gallery, photos(:regular_photo)
+  end
+
+  test "belongs to photographer" do
+    photo = photos(:cc_photo)
+    assert_equal users(:regular_user), photo.photographer
+  end
+
+  test "belongs to location" do
+    photo = photos(:cc_photo)
+    assert_equal locations(:great_barrier_reef), photo.location
+  end
+
+  test "has_place? true when location present" do
+    photo = photos(:cc_photo)
+    assert photo.has_place?
+  end
+
+  test "has_place? false when no location or site" do
+    photo = photos(:regular_photo)
+    assert_not photo.has_place?
+  end
+
+  test "description_truncated truncates long descriptions" do
+    photo = photos(:cc_photo)
+    assert photo.description_truncated.length <= 73
+  end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -77,6 +77,18 @@ class PostTest < ActiveSupport::TestCase
     assert_equal "Behind the science", post.category
   end
 
+  test "requires featured_user for early_career" do
+    post = Post.new(
+      title: "EC Post",
+      content_md: "Content",
+      post_type: "early_career",
+      user: users(:admin_user)
+    )
+    assert_not post.valid?
+    # Error may be on :featured_user (belongs_to) or :featured_user_id (conditional validation)
+    assert post.errors[:featured_user_id].any? || post.errors[:featured_user].any?
+  end
+
   test "generates slug from title" do
     post = Post.new(
       title: "A New Unique Post Title",

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class PostTest < ActiveSupport::TestCase
+  test "requires title" do
+    post = Post.new(content_md: "Content", post_type: "announcement", user: users(:admin_user), featured_user: users(:admin_user))
+    assert_not post.valid?
+    assert_includes post.errors[:title], "can't be blank"
+  end
+
+  test "requires content_md" do
+    post = Post.new(title: "Title", post_type: "announcement", user: users(:admin_user), featured_user: users(:admin_user))
+    assert_not post.valid?
+    assert_includes post.errors[:content_md], "can't be blank"
+  end
+
+  test "requires post_type" do
+    post = Post.new(title: "Title", content_md: "Content", user: users(:admin_user), featured_user: users(:admin_user))
+    assert_not post.valid?
+    assert_includes post.errors[:post_type], "can't be blank"
+  end
+
+  test "requires featured_publication for behind_the_science" do
+    post = Post.new(
+      title: "BTS Post",
+      content_md: "Content",
+      post_type: "behind_the_science",
+      user: users(:admin_user),
+      featured_user: users(:admin_user)
+    )
+    assert_not post.valid?
+    assert post.errors[:featured_publication_id].any? || post.errors[:featured_publication].any?
+  end
+
+  test "title must be unique" do
+    post = Post.new(
+      title: posts(:published_post).title,
+      content_md: "Content",
+      post_type: "announcement",
+      user: users(:admin_user),
+      featured_user: users(:admin_user)
+    )
+    assert_not post.valid?
+    assert_includes post.errors[:title], "has already been taken"
+  end
+
+  test "renders markdown to HTML on save" do
+    post = Post.new(
+      title: "Markdown Test Post",
+      content_md: "This is **bold** text.",
+      post_type: "announcement",
+      user: users(:admin_user),
+      featured_user: users(:admin_user)
+    )
+    post.save!
+    assert_match "<strong>bold</strong>", post.content_html
+  end
+
+  test "published scope returns non-draft posts" do
+    published = Post.published
+    assert_includes published, posts(:published_post)
+    assert_not_includes published, posts(:drafted_post)
+  end
+
+  test "drafted scope returns draft posts" do
+    drafted = Post.drafted
+    assert_includes drafted, posts(:drafted_post)
+    assert_not_includes drafted, posts(:published_post)
+  end
+
+  test "latest scope limits results" do
+    latest = Post.latest(1)
+    assert_equal 1, latest.length
+  end
+
+  test "category returns human-readable name" do
+    post = posts(:published_post)
+    assert_equal "Behind the science", post.category
+  end
+
+  test "generates slug from title" do
+    post = Post.new(
+      title: "A New Unique Post Title",
+      content_md: "Content here",
+      post_type: "announcement",
+      user: users(:admin_user),
+      featured_user: users(:admin_user)
+    )
+    post.save!
+    assert_equal "a-new-unique-post-title", post.slug
+  end
+end

--- a/test/models/publication_test.rb
+++ b/test/models/publication_test.rb
@@ -261,4 +261,50 @@ class PublicationTest < ActiveSupport::TestCase
       pub.save!
     end
   end
+
+  # -- Task 6: Scope tests --
+
+  test "validated scope returns publications with 2+ validations" do
+    validated = Publication.validated
+    assert_includes validated, publications(:scientific_article)
+    assert_not_includes validated, publications(:book_chapter)
+  end
+
+  test "unvalidated scope returns publications with fewer than 2 validations" do
+    unvalidated = Publication.unvalidated
+    assert_includes unvalidated, publications(:book_chapter)
+    assert_not_includes unvalidated, publications(:scientific_article)
+  end
+
+  test "latest scope returns publications ordered by year desc" do
+    latest = Publication.latest(3)
+    assert_equal 3, latest.length
+    assert latest.first.publication_year >= latest.last.publication_year
+  end
+
+  test "statistics scope filters by status and year" do
+    stats = Publication.statistics(:all, 2025)
+    assert stats.is_a?(ActiveRecord::Relation)
+  end
+
+  test "annual_counts groups by year" do
+    counts = Publication.annual_counts
+    assert counts.is_a?(Hash)
+  end
+
+  test "max_year returns highest publication year" do
+    assert_equal 2020, Publication.max_year
+  end
+
+  test "min_year returns lowest publication year" do
+    assert_equal 1969, Publication.min_year
+  end
+
+  test "max_depth returns highest max_depth" do
+    assert Publication.max_depth.is_a?(Integer)
+  end
+
+  test "min_depth returns lowest min_depth" do
+    assert Publication.min_depth.is_a?(Integer)
+  end
 end

--- a/test/models/publication_test.rb
+++ b/test/models/publication_test.rb
@@ -105,4 +105,60 @@ class PublicationTest < ActiveSupport::TestCase
   test "depth search, find one" do
     assert_equal [publications(:book_chapter), publications(:one)], (Publication.search "", Publication.default_search_params.merge("depth_range" => "200, 300")).to_a
   end
+
+  # -- Task 4: Validation and association tests --
+
+  test "requires title" do
+    pub = Publication.new(authors: "Author", publication_year: 2020, contributor: users(:admin_user))
+    assert_not pub.valid?
+    assert_includes pub.errors[:title], "can't be blank"
+  end
+
+  test "requires authors" do
+    pub = Publication.new(title: "Title", publication_year: 2020, contributor: users(:admin_user))
+    assert_not pub.valid?
+    assert_includes pub.errors[:authors], "can't be blank"
+  end
+
+  test "requires publication_year" do
+    pub = Publication.new(title: "Title", authors: "Author", contributor: users(:admin_user))
+    assert_not pub.valid?
+    assert_includes pub.errors[:publication_year], "can't be blank"
+  end
+
+  test "valid publication saves" do
+    pub = Publication.new(
+      title: "Valid Publication",
+      authors: "Author A",
+      publication_year: 2020,
+      contributor: users(:admin_user)
+    )
+    assert pub.valid?
+  end
+
+  test "belongs to journal" do
+    pub = publications(:scientific_article)
+    assert_equal journals(:open_journal), pub.journal
+  end
+
+  test "journal is optional" do
+    pub = publications(:one)
+    assert_nil pub.journal
+  end
+
+  test "belongs to contributor" do
+    pub = publications(:scientific_article)
+    assert_equal users(:admin_user), pub.contributor
+  end
+
+  test "has and belongs to many users" do
+    pub = publications(:scientific_article)
+    pub.users << users(:regular_user)
+    assert_includes pub.users, users(:regular_user)
+  end
+
+  test "has many validations" do
+    pub = publications(:scientific_article)
+    assert_equal 2, pub.validations.count
+  end
 end

--- a/test/models/publication_test.rb
+++ b/test/models/publication_test.rb
@@ -161,4 +161,104 @@ class PublicationTest < ActiveSupport::TestCase
     pub = publications(:scientific_article)
     assert_equal 2, pub.validations.count
   end
+
+  # -- Task 5: Instance method and callback tests --
+
+  test "open_access? returns true when journal is open access" do
+    pub = publications(:scientific_article)
+    assert pub.open_access?
+  end
+
+  test "open_access? returns false when journal is not open access" do
+    pub = publications(:book_chapter)
+    assert_equal journals(:closed_journal), pub.journal
+    assert_not pub.open_access?
+  end
+
+  test "open_access? returns false when no journal" do
+    pub = publications(:one)
+    assert_nil pub.journal
+    assert_not pub.open_access?
+  end
+
+  test "scientific_article? for scientific article" do
+    pub = publications(:scientific_article)
+    assert pub.scientific_article?
+  end
+
+  test "scientific_article? false for chapter" do
+    pub = publications(:book_chapter)
+    assert_not pub.scientific_article?
+  end
+
+  test "chapter? for chapter format" do
+    pub = publications(:book_chapter)
+    assert pub.chapter?
+  end
+
+  test "chapter? false for article" do
+    pub = publications(:scientific_article)
+    assert_not pub.chapter?
+  end
+
+  test "doi_url returns formatted DOI link" do
+    pub = publications(:scientific_article)
+    assert_equal "https://doi.org/10.1234/meso.2020", pub.doi_url
+  end
+
+  test "scholar_url returns Google Scholar link with DOI" do
+    pub = publications(:scientific_article)
+    url = pub.scholar_url
+    assert_match /scholar\.google\.com/, url
+    assert_match /10\.1234/, url
+  end
+
+  test "short_citation formats authors and year" do
+    pub = publications(:scientific_article)
+    citation = pub.short_citation
+    assert_match /Smith/, citation
+    assert_match /2020/, citation
+  end
+
+  test "title_truncated truncates long titles" do
+    pub = publications(:scientific_article)
+    assert pub.title_truncated.length <= 73  # 70 + "..."
+  end
+
+  test "validated? returns true with 2+ validations" do
+    pub = publications(:scientific_article)
+    assert pub.validated?
+  end
+
+  test "validated? returns false with fewer than 2 validations" do
+    pub = publications(:book_chapter)
+    assert_not pub.validated?
+  end
+
+  test "create_journal_from_name creates journal on save" do
+    pub = Publication.new(
+      title: "Test",
+      authors: "Author",
+      publication_year: 2020,
+      contributor: users(:admin_user),
+      new_journal_name: "Brand New Journal"
+    )
+    assert_difference "Journal.count", 1 do
+      pub.save!
+    end
+    assert_equal "Brand New Journal", pub.journal.name
+  end
+
+  test "create_journal_from_name does nothing when name blank" do
+    pub = Publication.new(
+      title: "Test",
+      authors: "Author",
+      publication_year: 2020,
+      contributor: users(:admin_user),
+      new_journal_name: ""
+    )
+    assert_no_difference "Journal.count" do
+      pub.save!
+    end
+  end
 end

--- a/test/models/publication_test.rb
+++ b/test/models/publication_test.rb
@@ -99,10 +99,10 @@ class PublicationTest < ActiveSupport::TestCase
   end
 
   test "depth search, find three, one" do
-    assert_equal [publications(:three), publications(:one)], (Publication.search "", Publication.default_search_params.merge("depth_range" => "40, 200")).to_a
+    assert_equal [publications(:three), publications(:scientific_article), publications(:book_chapter), publications(:one)], (Publication.search "", Publication.default_search_params.merge("depth_range" => "40, 200")).to_a
   end
 
   test "depth search, find one" do
-    assert_equal [publications(:one)], (Publication.search "", Publication.default_search_params.merge("depth_range" => "200, 300")).to_a
+    assert_equal [publications(:book_chapter), publications(:one)], (Publication.search "", Publication.default_search_params.merge("depth_range" => "200, 300")).to_a
   end
 end

--- a/test/models/species_test.rb
+++ b/test/models/species_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class SpeciesTest < ActiveSupport::TestCase
+  test "belongs to focusgroup" do
+    species = species(:chromis_margaritifer)
+    assert_equal focusgroups(:fish), species.focusgroup
+  end
+
+  test "abbreviation returns abbreviated name" do
+    species = species(:chromis_margaritifer)
+    abbrev = species.abbreviation
+    assert abbrev.start_with?("C")
+    assert_match /margaritifer/, abbrev
+  end
+
+  test "description returns name" do
+    species = species(:chromis_margaritifer)
+    assert_equal "Chromis margaritifer", species.description
+  end
+
+  test "short_description includes name and abbreviation" do
+    species = species(:chromis_margaritifer)
+    desc = species.short_description
+    assert_match /Chromis margaritifer/, desc
+    assert_match /;/, desc
+  end
+
+  test "species_code returns parameterized name" do
+    species = species(:chromis_margaritifer)
+    assert_equal "chromis-margaritifer", species.species_code
+  end
+
+  test "after_create triggers speciate" do
+    Species.skip_callback(:create, :after, :speciate)
+    species = Species.create!(name: "Acropora palmata", focusgroup: focusgroups(:corals))
+    assert species.persisted?
+  ensure
+    Species.set_callback(:create, :after, :speciate)
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class UserTest < ActiveSupport::TestCase
+  test "requires first_name" do
+    user = User.new(last_name: "Test", email: "test@example.com", password: "password123")
+    assert_not user.valid?
+    assert_includes user.errors[:first_name], "can't be blank"
+  end
+
+  test "requires last_name" do
+    user = User.new(first_name: "Test", email: "test@example.com", password: "password123")
+    assert_not user.valid?
+    assert_includes user.errors[:last_name], "can't be blank"
+  end
+
+  test "requires valid email" do
+    user = User.new(first_name: "Test", last_name: "User", email: "notanemail", password: "password123")
+    assert_not user.valid?
+    assert user.errors[:email].any?
+  end
+
+  test "validates website format when present" do
+    user = users(:regular_user)
+    user.website = "not-a-url"
+    assert_not user.valid?
+  end
+
+  test "allows blank website" do
+    user = users(:regular_user)
+    user.website = ""
+    assert user.valid?
+  end
+
+  test "editor_or_admin? true for admin" do
+    assert users(:admin_user).editor_or_admin?
+  end
+
+  test "editor_or_admin? true for editor" do
+    assert users(:editor_user).editor_or_admin?
+  end
+
+  test "editor_or_admin? false for regular user" do
+    assert_not users(:regular_user).editor_or_admin?
+  end
+
+  test "full_name returns last, first" do
+    user = users(:admin_user)
+    assert_equal "User, Admin", user.full_name
+  end
+
+  test "full_name_normal returns first last" do
+    user = users(:admin_user)
+    assert_equal "Admin User", user.full_name_normal
+  end
+
+  test "belongs to organisation" do
+    user = users(:admin_user)
+    assert_equal organisations(:csiro), user.organisation
+  end
+
+  test "organisation is optional" do
+    user = users(:regular_user)
+    assert_nil user.organisation
+    assert user.valid?
+  end
+
+  test "paginates at 100" do
+    assert_equal 100, User.default_per_page
+  end
+
+  test "create_organisation_from_name attempts to create organisation on save" do
+    user = users(:regular_user)
+    user.new_organisation_name = "New Org"
+    # Organisation requires country which the callback doesn't provide,
+    # so the organisation is built but not persisted
+    user.save!
+    org = user.organisation
+    assert_equal "New Org", org.name
+    assert_not org.persisted?
+  end
+end

--- a/test/models/validation_test.rb
+++ b/test/models/validation_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class ValidationTest < ActiveSupport::TestCase
+  test "requires user_id" do
+    v = Validation.new(validatable_type: "Publication", validatable_id: 1)
+    assert_not v.valid?
+    assert_includes v.errors[:user_id], "can't be blank"
+  end
+
+  test "requires validatable_type" do
+    v = Validation.new(user: users(:admin_user), validatable_id: 1)
+    assert_not v.valid?
+    assert_includes v.errors[:validatable_type], "can't be blank"
+  end
+
+  test "requires validatable_id" do
+    v = Validation.new(user: users(:admin_user), validatable_type: "Publication")
+    assert_not v.valid?
+    assert_includes v.errors[:validatable_id], "can't be blank"
+  end
+
+  test "belongs to user" do
+    v = validations(:validation_one)
+    assert_equal users(:admin_user), v.user
+  end
+
+  test "belongs to validatable publication" do
+    v = validations(:validation_one)
+    assert_equal publications(:scientific_article), v.validatable
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,11 +3,9 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
-  # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
-  #
-  # Note: You'll currently still have to declare fixtures explicitly in integration tests
-  # -- they do not yet inherit this setting
   fixtures :all
+end
 
-  # Add more helper methods to be used by all tests here...
+class ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
 end


### PR DESCRIPTION
## Summary
- Add Devise integration test helpers
- Create fixtures for all models (users, journals, locations, species, etc.)
- Add model tests for Publication, User, Post, Photo, Species, Location, Journal, Validation
- Add controller integration tests for Publications, Pages, Stats, Admin
- Add helper tests for ApplicationHelper, PublicationsHelper, DualRangeHelper
- Total: ~162 tests covering critical paths for regression detection during upgrades

## Test plan
- [x] `rails test` — all 162 tests pass