### PR TITLE
Replace <<< Back links with breadcrumb navigation

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -29,7 +29,7 @@ class StatsController < ApplicationController
     @status = Status::ALL
     @year = params[:year].to_i
     @title = "All Publications"
-    @stats_subtitle = "Statistics up to #{@year}"
+    @stats_subtitle = "Stats up to #{@year}"
     @publications = Publication.statistics @status, @year
 
     render :index
@@ -40,7 +40,7 @@ class StatsController < ApplicationController
     @status = Status::VALIDATED
     @year = params[:year]
     @title = "Validated Publications"
-    @stats_subtitle = "Statistics up to #{@year}"
+    @stats_subtitle = "Stats up to #{@year}"
     @publications = Publication.statistics @status, @year
 
     render :index

--- a/app/views/admin/base/index.html.erb
+++ b/app/views/admin/base/index.html.erb
@@ -1,4 +1,5 @@
 <% title("Admin") %>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", nil]] } %>
 <h3>Admin</h3>
 
 <div class="row mb-4">

--- a/app/views/admin/posts/dashboard.html.erb
+++ b/app/views/admin/posts/dashboard.html.erb
@@ -1,8 +1,6 @@
 <% title("Posts Dashboard") %>
 <h3 class="page-title">Posts <small>Dashboard</small></h3>
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", admin_root_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", nil]] } %>
 <hr/>
 <div class="row">
   <div class="col-sm-4">Published: <%= link_to "#{pluralize(@published_post_count, 'post')}", admin_posts_path %></div>

--- a/app/views/admin/posts/drafts.html.erb
+++ b/app/views/admin/posts/drafts.html.erb
@@ -1,8 +1,6 @@
 <% title("Post Drafts") %>
 <h3 class="page-title">Posts <small>Drafts</small></h3>
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", dashboard_admin_posts_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["Drafts", nil]] } %>
 <hr/>
 
 <p class="pagination-summary"><%= page_entries_info @posts %></p>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -1,8 +1,6 @@
 <% title("Edit #{@post.title}") %>
 <h3 class="page-title">Edit Post <small><%= @post.title %></small></h3>
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", dashboard_admin_posts_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], [@post.title, nil]] } %>
 <hr/>
 
 <%= render 'form' %>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,8 +1,6 @@
 <% title("Published Posts") %>
 <h3 class="page-title">Posts <small>Published</small></h3>
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", dashboard_admin_posts_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["Published", nil]] } %>
 <hr/>
 
 <p class="pagination-summary"><%= page_entries_info @posts %></p>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -1,8 +1,6 @@
 <% title("New Post") %>
 <h3 class="page-title">Add a New Post</h3>
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", dashboard_admin_posts_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["New", nil]] } %>
 <hr/>
 
 <%= render 'form' %>

--- a/app/views/admin/publications/dashboard.html.erb
+++ b/app/views/admin/publications/dashboard.html.erb
@@ -1,8 +1,6 @@
 <% title("Published Posts") %>
 <h3 class="page-title">Publications</h3>
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", dashboard_admin_posts_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Publications", nil]] } %>
 <hr/>
 
 <div class="col-sm-12">

--- a/app/views/admin/publications/index.html.erb
+++ b/app/views/admin/publications/index.html.erb
@@ -1,8 +1,6 @@
 <% title("Published Posts") %>
 <h3 class="page-title">Posts <small>Published</small></h3>
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", dashboard_admin_posts_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Publications", dashboard_admin_publications_path], ["All", nil]] } %>
 <hr/>
 
 <%= paginate @publications %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,8 +1,6 @@
 <% title("Edit User: #{@user.email}") %>
 
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", admin_users_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Users", admin_users_path], [@user.email, nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,8 +1,6 @@
 <% title("Users") %>
 
-<div class="mb-1">
-  <strong><%= link_to "<<< Back", admin_root_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Users", nil]] } %>
 
 <div class="card">
   <div class="card-header d-flex justify-content-between align-items-center">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,5 @@
-<%= render partial: "layouts/page_title",
-           locals: {title: "Edit Your Profile",
-           backlink: member_pages_path(current_user.id) } %>
+<% title("Edit Profile") %>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["People", members_pages_path], [current_user.full_name_normal, member_pages_path(current_user.id)], ["Edit Profile", nil]] } %>
 
 <%= form_for(resource, as: resource_name,
              url: registration_path(resource_name),

--- a/app/views/expeditions/edit.html.erb
+++ b/app/views/expeditions/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Edit expedition",
           subtitle: @expedition.title,
-          backlink: expeditions_path } %>
+          breadcrumbs: [["Expeditions", expeditions_path], [@expedition.title, nil]] } %>
 
 <%= form_for(@expedition) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>

--- a/app/views/expeditions/new.html.erb
+++ b/app/views/expeditions/new.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "New expedition",
           subtitle: "",
-          backlink: expeditions_path } %>
+          breadcrumbs: [["Expeditions", expeditions_path], ["New", nil]] } %>
 
 <%= form_for(@expedition) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>

--- a/app/views/expeditions/show.html.erb
+++ b/app/views/expeditions/show.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Expeditions",
                 subtitle: "#{@expedition.title}",
-                backlink: expeditions_path } %>
+                breadcrumbs: [["Expeditions", expeditions_path], [@expedition.title, nil]] } %>
 
 <div class="row">
   <div class="col-sm-12">

--- a/app/views/layouts/_page_title.html.erb
+++ b/app/views/layouts/_page_title.html.erb
@@ -6,10 +6,8 @@
   <% end %>
 </div>
 
-<% if backlink %>
-  <div class="mb-1">
-    <strong><%= link_to '<<< Back', backlink, style: "text-decoration: none;" %></strong>
-  </div>
+<% if defined?(breadcrumbs) && breadcrumbs.present? %>
+  <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: breadcrumbs } %>
 <% end %>
 
 <div class="row">

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Edit location",
           subtitle: "#{@location.description}",
-          backlink: locations_path } %>
+          breadcrumbs: [["Locations", locations_path], [@location.description, nil]] } %>
 
 <%= form_for(@location) do |f| %>
   <%= render partial: 'form', locals: {f: f, 

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Locations",
-                backlink: root_path } %>
+                breadcrumbs: [["Locations", nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/locations/new.html.erb
+++ b/app/views/locations/new.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "New location",
           subtitle: "",
-          backlink: locations_path } %>
+          breadcrumbs: [["Locations", locations_path], ["New", nil]] } %>
 
 <%= form_for(@location) do |f| %>
   <%= render partial: 'form', locals: {f: f, 

--- a/app/views/meetings/edit.html.erb
+++ b/app/views/meetings/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Edit meeting",
           subtitle: @meeting.title,
-          backlink: meetings_path } %>
+          breadcrumbs: [["Meetings", meetings_path], [@meeting.title, nil]] } %>
 
 <%= form_for(@meeting) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>

--- a/app/views/meetings/new.html.erb
+++ b/app/views/meetings/new.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "New meeting",
           subtitle: "",
-          backlink: meetings_path } %>
+          breadcrumbs: [["Meetings", meetings_path], ["New", nil]] } %>
 
 <%= form_for(@meeting) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>

--- a/app/views/pages/_post_announcement.html.erb
+++ b/app/views/pages/_post_announcement.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: @post.title,
           supertitle: "Announcement",
-          backlink: posts_pages_path } %>
+          breadcrumbs: [["News", posts_pages_path], [@post.title, nil]] } %>
 <p class="text-muted mb-4" style="font-size: 0.85em;">
   <%= @post.created_at.strftime("%B %-d, %Y") %> · Posted by <%= link_to "#{@post.user.first_name} #{@post.user.last_name}", member_pages_path(@post.user), style: "text-decoration: none;" %>
   <% if current_user.try(:editor_or_admin?) %>

--- a/app/views/pages/_post_behind.html.erb
+++ b/app/views/pages/_post_behind.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: @publication.title,
           supertitle: "Behind the Science",
-          backlink: posts_pages_path } %>
+          breadcrumbs: [["News", posts_pages_path], [@publication.title_truncated, nil]] } %>
 <p class="text-muted mb-4" style="font-size: 0.85em;">
   <%= @post.created_at.strftime("%B %-d, %Y") %> · Posted by <%= link_to "#{@post.user.first_name} #{@post.user.last_name}", member_pages_path(@post.user), style: "text-decoration: none;" %>
   <% if current_user.try(:editor_or_admin?) %>

--- a/app/views/pages/_post_ecr.html.erb
+++ b/app/views/pages/_post_ecr.html.erb
@@ -3,7 +3,7 @@
 <%= render partial: "layouts/page_title",
        locals: { title: "An Interview with #{@researcher.full_name_normal}",
           supertitle: "Early Career Scientist",
-          backlink: posts_pages_path } %>
+          breadcrumbs: [["News", posts_pages_path], [@researcher.full_name_normal, nil]] } %>
 <p class="text-muted mb-4" style="font-size: 0.85em;">
   <%= @post.created_at.strftime("%B %-d, %Y") %> · Posted by <%= link_to "#{@post.user.first_name} #{@post.user.last_name}", member_pages_path(@post.user), style: "text-decoration: none;" %>
   <% if current_user.try(:editor_or_admin?) %>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "About",
-                backlink: root_path } %>
+                breadcrumbs: [["About", nil]] } %>
 <div class="row">
   <div class="col-sm-8">
     When extracting data from this portal for publication, please cite:

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -10,7 +10,7 @@
 
 
 <!-- Latest news -->
-<h5 class="mt-5"><strong>Latest Posts</strong></h5>
+<h5 class="mt-5"><strong>Latest News</strong></h5>
 <div class="row mb-4">
   <%= render partial: 'shared/post_summary_small', collection: @posts, as: :post %>
 </div>

--- a/app/views/pages/media_gallery.html.erb
+++ b/app/views/pages/media_gallery.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Media Gallery",
-                backlink: root_path } %>
+                breadcrumbs: [["Media Gallery", nil]] } %>
 
 <div class="row">
   <div class="col-sm-12">

--- a/app/views/pages/members.html.erb
+++ b/app/views/pages/members.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "People",
-                backlink: root_path } %>
+                breadcrumbs: [["People", nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/pages/posts.html.erb
+++ b/app/views/pages/posts.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "layouts/page_title",
-       locals: {title: "Latest Posts",
-                backlink: root_path } %>
+       locals: {title: "News",
+                breadcrumbs: [["News", nil]] } %>
 
 <%= paginate @posts %>
 <% @posts.each do |post| %>

--- a/app/views/pages/show_member.html.erb
+++ b/app/views/pages/show_member.html.erb
@@ -1,6 +1,4 @@
-<div class="mb-1">
-  <strong><%= link_to '<<< Back', members_pages_path, style: "text-decoration: none;" %></strong>
-</div>
+<%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["People", members_pages_path], ["#{@user.first_name} #{@user.last_name}", nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/pages/tutorial.html.erb
+++ b/app/views/pages/tutorial.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Data tutorial",
-                backlink: root_path } %>
+                breadcrumbs: [["Tutorial", nil]] } %>
 
 <%= markdown(File.read(Rails.root.join("public", "tutorial.md"))) %>

--- a/app/views/photos/edit.html.erb
+++ b/app/views/photos/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        	   locals: {title: "Edit photo",
            subtitle: @photo.description,
-           backlink: photos_path } %>
+           breadcrumbs: [["Images", photos_path], [@photo.description_truncated, nil]] } %>
 
 <%= form_for(@photo) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>

--- a/app/views/photos/index.html.erb
+++ b/app/views/photos/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Images",
-                backlink: root_path } %>
+                breadcrumbs: [["Images", nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/photos/new.html.erb
+++ b/app/views/photos/new.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        	   locals: {title: "New photo",
            subtitle: "",
-           backlink: photos_path } %>
+           breadcrumbs: [["Images", photos_path], ["New", nil]] } %>
 
 <%= form_for(@photo) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Images",
        			subtitle: @photo.description_truncated,
-                backlink: photos_path } %>
+                breadcrumbs: [["Images", photos_path], [@photo.description_truncated, nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/publications/behind_edit.html.erb
+++ b/app/views/publications/behind_edit.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Behind the science",
           subtitle: @publication.short_citation,
-          backlink: publications_path } %>
+          breadcrumbs: [["Publications", publications_path], ["Edit Article", nil]] } %>
 
 <div class="row">
   <div class="col-sm-12">

--- a/app/views/publications/edit.html.erb
+++ b/app/views/publications/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Editing \"#{@publication.title_truncated}\"",
-          backlink: publication_path(@publication) } %>
+          breadcrumbs: [["Publications", publications_path], [@publication.title_truncated, publication_path(@publication)], ["Edit", nil]] } %>
 
 <%= form_for(@publication) do |f| %>
   <%= render partial: 'form_errorheader', locals: {f: f} %>

--- a/app/views/publications/edit_meta.html.erb
+++ b/app/views/publications/edit_meta.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: 'layouts/page_title', 
 		   locals: {title: 'Edit publication',
 					subtitle: @publication.title_truncated,
-					backlink: publication_path } %>
+					breadcrumbs: [["Publications", publications_path], [@publication.title_truncated, publication_path(@publication)], ["Edit Metadata", nil]] } %>
 
 <%= form_for(@publication) do |f| %>
 	<%= render partial: 'form_errorheader', locals: {f: f} %>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -4,7 +4,7 @@
        locals: { title: "Publications",
                  subtitle: subtitle,
                  supertitle: supertitle,
-                 backlink: root_path } %>
+                 breadcrumbs: [["Publications", nil]] } %>
 
 <%# Wide screen for search results or editor view %>
 <% sidebar = !(params[:search].present? || current_user.try(:editor_or_admin?)) %>

--- a/app/views/publications/new.html.erb
+++ b/app/views/publications/new.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'layouts/page_title', 
 		   locals: {title: 'New publication',
-					backlink: publications_path } %>
+					breadcrumbs: [["Publications", publications_path], ["New", nil]] } %>
 
 <%= form_for(@publication) do |f| %>
 	<%= render partial: 'form_errorheader', locals: {f: f} %>

--- a/app/views/publications/old_behind.html.erb
+++ b/app/views/publications/old_behind.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Behind the science",
           subtitle: @publication.short_citation,
-          backlink: publications_path } %>
+          breadcrumbs: [["Publications", publications_path], ["Behind the Science", nil]] } %>
 
 <div class="row">
   <div class="col-sm-12">

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Publications",
           subtitle: @publication.short_citation,
-          backlink: publications_path } %>
+          breadcrumbs: [["Publications", publications_path], [@publication.title_truncated, nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,0 +1,12 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb mb-2" style="font-size: 0.85em;">
+    <li class="breadcrumb-item"><%= link_to "Home", root_path %></li>
+    <% breadcrumbs.each_with_index do |(label, path), index| %>
+      <% if index == breadcrumbs.size - 1 %>
+        <li class="breadcrumb-item active" aria-current="page"><%= label %></li>
+      <% else %>
+        <li class="breadcrumb-item"><%= link_to label, path %></li>
+      <% end %>
+    <% end %>
+  </ol>
+</nav>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
 	       locals: {title: "Edit site",
 	          subtitle: "#{@site.site_name}",
-	          backlink: sites_path } %>
+	          breadcrumbs: [["Sites", sites_path], [@site.site_name, nil]] } %>
 
 <%= form_for(@site) do |f| %>
   <%= render partial: 'form', locals: {f: f, site: @site} %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Sites",
        			subtitle: @site.site_name,
-                backlink: root_path } %>
+                breadcrumbs: [["Sites", sites_path], [@site.site_name, nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">

--- a/app/views/species/_show.html.erb
+++ b/app/views/species/_show.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
            locals: {
              title: "<i>#{object.name}</i>".html_safe,
-             backlink: species_index_path
+             breadcrumbs: [["Species", species_index_path], [object.name, nil]]
            } %>
 
 <div class="row">

--- a/app/views/species/index.html.erb
+++ b/app/views/species/index.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "layouts/page_title",
        	   locals: {title: "Species",
-            		backlink: root_path } %>
+            		breadcrumbs: [["Species", nil]] } %>
 
 <div class="row">
   <div class="col-sm-12">

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -2,7 +2,7 @@
       title: @stats_subtitle,
       supertitle: @title,
       subtitle: raw("<span class=\"badge fw-normal float-end\" style=\"font-size: 0.65em; color: #c7254e; background-color: #f9f2f4;\">#{@latest_update.to_date}</span>"),
-      backlink: root_path
+      breadcrumbs: [["Stats", nil]]
     } %>
 <div class="row">
   <div class="col-sm-12">

--- a/app/views/summary/_show.html.erb
+++ b/app/views/summary/_show.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
            locals: {
              title: title,
-             backlink: root_path
+             breadcrumbs: [[title, nil]]
            } %>
 
 <div class="row">


### PR DESCRIPTION
## Summary

Replaced all `<<< Back` links and `backlink:` parameters with proper Bootstrap 5 breadcrumb navigation across the entire app.

**New shared partial**: `app/views/shared/_breadcrumbs.html.erb` — renders a Bootstrap breadcrumb nav from an array of `[label, path]` pairs. The last item is the current page (no link).

**Updated `_page_title.html.erb`** to accept `breadcrumbs:` instead of `backlink:`. The `backlink:` parameter has been removed.

### Breadcrumb trails by section:

**Public pages:**
- Publications: `Home > Publications`, `Home > Publications > [Title]`, `Home > Publications > [Title] > Edit`
- Stats: `Home > Statistics`
- Species: `Home > Species`, `Home > Species > [Name]`
- Locations: `Home > Locations`, `Home > Locations > [Name]`
- Images: `Home > Images`, `Home > Images > [Description]`
- People: `Home > People`, `Home > People > [Name]`
- Latest Posts: `Home > Latest Posts`, `Home > Latest Posts > [Title]`
- About, Tutorial, Media Gallery: `Home > [Page]`
- Edit Profile: `Home > People > [Name] > Edit Profile`

**Post show pages:**
- Behind the Science: `Home > Latest Posts > [Title]`
- Early Career: `Home > Latest Posts > [Name]`
- Announcement: `Home > Latest Posts > [Title]`

**Admin pages:**
- Users: `Home > Admin > Users`, `Home > Admin > Users > [email]`
- Posts: `Home > Admin > Posts`, `Home > Admin > Posts > Published/Drafts/New/[Title]`
- Publications: `Home > Admin > Publications`, `Home > Admin > Publications > All`

**Other:**
- Expeditions, Meetings, Sites: all have proper breadcrumb trails
- Summary pages: `Home > [Section]`

## Test Plan

- [x] All 162 automated tests pass
- [x] Every page that had `<<< Back` now shows breadcrumbs
- [x] Breadcrumb links navigate correctly
- [x] Current page (last item) is not a link
- [x] Home link always goes to root