### PR TITLE
UI polish: publications list, stats intro, profile images, bug fixes

### DIFF
--- a/app/assets/stylesheets/railsbricks_custom.scss
+++ b/app/assets/stylesheets/railsbricks_custom.scss
@@ -365,4 +365,12 @@ img {
     padding-top: 20px;
   }
 }
+
+// Newsfeed publication titles: link colour, underline on hover only
+.newsfeed-title {
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+}
 //***********************************************************

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,7 +4,7 @@ class PagesController < ApplicationController
   def home
     @locations = Location.published
     @posts = Post.latest(2)
-    @publications = Publication.latest(12)
+    @publications = Publication.latest(20)
     @latest_update = Publication.maximum(:updated_at)
   end
 

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -140,7 +140,7 @@ module StatsHelper
   # Counts the number of cumulative locations in publications over time (years)
   def count_locations_over_time(publications, last_year)
     # Get a list of locations for each year
-    year_location_list = Hash.new(0)
+    year_location_list = {}
     publications.each do |publication|
       locations = publication.locations
       year_key = publication.publication_year.to_s
@@ -158,7 +158,7 @@ module StatsHelper
     cumulative_locations = Set.new()
     year_range.each do |year|
       categories << year.to_s
-      cumulative_locations.merge(year_location_list[year.to_s])
+      cumulative_locations.merge(year_location_list[year.to_s] || [])
       values << cumulative_locations.count
     end
     return categories, values

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,7 @@
   <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %>
 
   <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+  <%= yield :head %>
   <%= javascript_include_tag "proj4" %>
   <%= javascript_include_tag "highcharts" %>
   <%= javascript_include_tag "highcharts-more" %>

--- a/app/views/pages/_newsfeed.html.erb
+++ b/app/views/pages/_newsfeed.html.erb
@@ -1,6 +1,41 @@
 <% publications.each do |publication| %>
-  <table class="table table-striped">
-    <%= render partial: "publications/publication", 
-               locals: { publication: publication } %>
-  </table>
+  <div class="d-flex align-items-start<%= ' mb-3 pb-3 border-bottom' unless publication == publications.last %>">
+    <div class="flex-shrink-0" style="width: 60px;">
+      <% if publication.pdf.attached? %>
+        <%= link_to publication do %>
+          <%= image_tag publication.pdf.preview(resize: "60x84>"), style: "width: 60px; border-radius: 3px; box-shadow: 0 1px 3px rgba(0,0,0,0.15);" %>
+        <% end %>
+      <% else %>
+        <%= link_to publication do %>
+          <div class="d-flex align-items-center justify-content-center rounded" style="width: 60px; height: 84px; background-color: #f0f1f3;">
+            <i class="bi bi-file-earmark-text text-muted"></i>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+    <div class="flex-grow-1 ms-3">
+      <div>
+        <strong><%= link_to truncate(publication.title, length: 120), publication, class: "newsfeed-title" %></strong>
+      </div>
+      <div style="font-size: 0.9em;">
+        <%= format_authors(publication) %> (<%= publication.publication_year %>)
+      </div>
+      <% if publication.scientific_article? && publication.journal %>
+        <div class="text-muted" style="font-size: 0.9em;">
+          <em><%= publication.journal.name %></em>
+        </div>
+      <% end %>
+      <div class="mt-1 d-flex align-items-center gap-1">
+        <span class="badge border text-secondary" style="font-size: 0.7em; font-weight: normal;"><%= publication.publication_format.titleize %></span>
+        <% if publication.open_access? %>
+          <span class="badge border border-success text-success" style="font-size: 0.7em; font-weight: normal;">Open Access</span>
+        <% end %>
+        <% if publication.DOI.present? %>
+          <%= link_to publication.doi_url, class: "text-muted ms-auto", style: "font-size: 0.85em; text-decoration: none;" do %>
+            <i class="bi bi-link-45deg"></i> DOI
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  </div>
 <% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -20,7 +20,7 @@
   <div class="col-sm-7">
     <div class="card">
       <div class="card-header"><strong>Latest Publications</strong></div>
-      <div class="card-body">
+      <div class="card-body" style="background-color: #f8f9fa;">
         <%= render partial: 'newsfeed',
                    locals: { publications: @publications } %>
       </div>

--- a/app/views/pages/show_member.html.erb
+++ b/app/views/pages/show_member.html.erb
@@ -46,15 +46,12 @@
     <% if @user.publications.count > 0 %>
       <div class="card">
         <div class="card-header"><strong>Publications</strong></div>
-        <div class="card-body">
+        <div class="card-body" style="background-color: #f8f9fa;">
           <p class="p-2 rounded text-muted" style="background-color: #e8f4fd; font-size: 0.85em;">
             Only publications relevant to mesophotic reefs are indexed.
           </p>
-          <table class="table table-sm table-striped">
-            <% @user.publications.each do |publication| %>
-              <%= render publication %>
-            <% end %>
-          </table>
+          <%= render partial: 'pages/newsfeed',
+                     locals: { publications: @user.publications.includes(:users, :journal).order('publication_year DESC, created_at DESC') } %>
         </div>
       </div>
     <% end %>

--- a/app/views/stats/_notes.html.erb
+++ b/app/views/stats/_notes.html.erb
@@ -1,16 +1,21 @@
-<div class="card">
+<div class="card mb-3" style="background-color: #f8f9fa;">
   <div class="card-body">
-    <p>The following graphs summarize the metadata across the <code><%= @publications.length %></code> scientific articles in this database that are validated and present original data from mesophotic depths. See the <%= link_to "Data Tutorial", tutorial_pages_path %> on how to produce similar figures yourself in R.</p>
-
-    <p>
-      All publications up to:
-      <%= link_to "2008", all_stats_path(2008) %>
-      <%= link_to "2023", all_stats_path(2023) %>
-    </p>
-    <p>
-      Validated publications up to:
-      <%= link_to "2008", validated_stats_path(2008) %>
-      <%= link_to "2023", validated_stats_path(2023) %>
-    </p>
+    <div class="d-flex align-items-center">
+      <div class="flex-shrink-0 me-3 d-flex flex-column gap-1">
+        <div class="btn-group btn-group-sm">
+          <%= link_to "All", all_stats_path(@year || 2023), class: "btn #{@status == :all ? 'btn-secondary' : 'btn-outline-secondary'}", style: "min-width: 70px;" %>
+          <%= link_to "Validated", validated_stats_path(@year || 2023), class: "btn #{@status == :validated ? 'btn-secondary' : 'btn-outline-secondary'}", style: "min-width: 70px;" %>
+        </div>
+        <div class="btn-group btn-group-sm">
+          <%= link_to "2008", @status == :validated ? validated_stats_path(2008) : all_stats_path(2008), class: "btn #{@year.to_i == 2008 ? 'btn-secondary' : 'btn-outline-secondary'}", style: "min-width: 70px;" %>
+          <%= link_to "2023", @status == :validated ? validated_stats_path(2023) : all_stats_path(2023), class: "btn #{@year.to_i == 2023 ? 'btn-secondary' : 'btn-outline-secondary'}", style: "min-width: 70px;" %>
+        </div>
+      </div>
+      <div>
+        <div style="line-height: 1.2;"><span style="font-size: 1.5em; font-weight: bold;"><%= @publications.length %></span> <span class="text-muted" style="font-size: 0.9em;">articles</span></div>
+        <div class="text-muted" style="font-size: 0.9em;">Metadata summary of validated scientific articles with original mesophotic data.</div>
+        <div class="text-muted" style="font-size: 0.9em;">See the <%= link_to "Data Tutorial", tutorial_pages_path %> for how to produce similar figures in R.</div>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,3 +1,6 @@
+<% content_for :head do %>
+  <meta name="turbolinks-cache-control" content="no-preview">
+<% end %>
 <%= render partial: "layouts/page_title", locals: {
       title: @stats_subtitle,
       supertitle: @title,

--- a/app/views/summary/_show.html.erb
+++ b/app/views/summary/_show.html.erb
@@ -14,15 +14,11 @@
         <%= render partial: 'dropdown',
                    locals: { objects: objects, object: object, model: title.downcase } %>
       </div>
-      <div class="card-body">
+      <div class="card-body" style="background-color: #f8f9fa;">
         <%= paginate publications %> [<%= publications.total_count %> results] &bullet; <%= link_to "Download as CSV", summary_path(title.downcase, object.id, format: :csv) %>
         <br><br>
-
-	      <table class="table table-striped">
-				  <% publications.includes(:users, :journal).order('publication_year DESC, created_at DESC').each do |publication| %>
-				    <%= render publication %>
-				  <% end %>
-				</table>
+        <%= render partial: 'pages/newsfeed',
+                   locals: { publications: publications.includes(:users, :journal).order('publication_year DESC, created_at DESC') } %>
         <%= paginate publications %> [<%= publications.total_count %> results] &bullet; <%= link_to "Download as CSV", summary_path(title.downcase, object.id, format: :csv) %>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

- **Restyle home page publications list** — flex layout with smaller thumbnails, outline format/open-access tags, DOI links, soft grey background, 20 publications
- **Restyle summary and member pages** — reuse the same publication list layout for platforms, fields, focusgroups, locations, species, and member profiles
- **Restyle stats page intro** — prominent article count, All/Validated and 2008/2023 filter button groups
- **Reserve space for profile images** — placeholder backgrounds on member show, contributors, featured member
- **Fix stats_helper bug** — `Hash.new(0)` returned integer instead of Set for missing years in `count_locations_over_time`
- **Fix Turbolinks preview flash on stats page** — `no-preview` meta tag prevents stale graph snapshot showing before fresh render
- **Add `yield :head`** to layout for per-page head injection

## Test plan

- [x] Home page: 20 publications with thumbnails, outline tags, DOI links
- [x] Summary pages (platforms, fields, etc.): same publication list styling
- [x] Member profile: publication list with grey background
- [x] Stats page: filter buttons work, no preview flash on navigation
- [x] About page: contributor images have placeholder backgrounds
- [x] Members page: featured member image has placeholder background
- [x] All 162 tests pass