### PR TITLE
Restyle admin publications dashboard

### DIFF
--- a/app/controllers/admin/publications_controller.rb
+++ b/app/controllers/admin/publications_controller.rb
@@ -7,7 +7,7 @@ class Admin::PublicationsController < Admin::BaseController
   ]
 
   def dashboard
-	  @publications = Publication.all.page(params[:page])
+	  @publications = Publication.includes(:users, :journal).page(params[:page])
   end
 
   def destroy

--- a/app/views/admin/publications/dashboard.html.erb
+++ b/app/views/admin/publications/dashboard.html.erb
@@ -4,11 +4,11 @@
 <hr/>
 
 <div class="col-sm-12">
-	<%= paginate @publications %>
-	<table class="table table-striped">
-	<% @publications.each do |publication| %>
-  	<%= render "publications/publication", publication: publication %>
-	<% end %>
-	</table>
-	<%= paginate @publications %>
+  <%= paginate @publications %>
+  <div class="card mt-2">
+    <div class="card-body" style="background-color: #f8f9fa;">
+      <%= render partial: 'pages/newsfeed', locals: { publications: @publications } %>
+    </div>
+  </div>
+  <%= paginate @publications %>
 </div>


### PR DESCRIPTION
## Summary

- Switched admin publications dashboard from table layout to the newsfeed publication list styling (matching home page, summary pages, and member profiles)
- Added eager loading (`includes(:users, :journal)`) to avoid N+1 queries
- Preserved original ordering