### PR TITLE
More caching: maps, member pages, media gallery, summary photos, Open Access logo

### DIFF
--- a/app/assets/images/open_access.svg
+++ b/app/assets/images/open_access.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="1000" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata><rdf:RDF><cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:creator>art designer at PLoS, modified by Wikipedia users Nina, Beao, JakobVoss, and AnonMoos</dc:creator>
+    <dc:description>Open Access logo, converted into svg, designed by PLoS. This version with transparent background.</dc:description>
+    <dc:source>http://commons.wikimedia.org/wiki/File:Open_Access_logo_PLoS_white.svg</dc:source>
+    <dc:license rdf:resource="http://creativecommons.org/licenses/by-sa/3.0/"/>
+    <cc:license rdf:resource="http://creativecommons.org/licenses/by-sa/3.0/"/>
+    <cc:attributionName>art designer at PLoS, modified by Wikipedia users Nina, Beao, JakobVoss, and AnonMoos</cc:attributionName>
+    <cc:attributionURL>http://www.plos.org/</cc:attributionURL>
+  </cc:Work></rdf:RDF></metadata>
+  <g stroke="#f68212" stroke-width="104.764" fill="none">
+    <path d="M111.387,308.135V272.408A209.21,209.214 0 0,1 529.807,272.408V530.834"/>
+    <circle cx="320.004" cy="680.729" r="256.083"/>
+  </g>
+  <circle fill="#f68212" cx="321.01" cy="681.659" r="86.4287"/>
+</svg>

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,12 +1,14 @@
 class MapsController < ApplicationController
   def world_map
-    data = params[:model].singularize.classify.constantize.where(id: params[:ids].split(','))
-
-    render partial: 'shared/world_map_clickable',
-           locals: { title: params[:model].pluralize.titleize,
-                     data: get_coordinates(data, params[:z]),
-                     backgroundcolor: params[:backgroundcolor],
-                     height: params[:height] }
+    cached = Rails.cache.fetch(["world_map", params[:model], params[:ids], params[:z], Publication.maximum(:updated_at)]) do
+      data = params[:model].singularize.classify.constantize.where(id: params[:ids].split(','))
+      render_to_string partial: 'shared/world_map_clickable',
+             locals: { title: params[:model].pluralize.titleize,
+                       data: get_coordinates(data, params[:z]),
+                       backgroundcolor: params[:backgroundcolor],
+                       height: params[:height] }
+    end
+    render html: cached.html_safe
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,7 +21,7 @@ class PagesController < ApplicationController
   end
 
   def media_gallery
-    @photos = Photo.media_gallery.order(id: :desc).page(params[:page])
+    @photos = Photo.media_gallery.order(id: :desc).includes(image_attachment: :blob).page(params[:page])
   end
 
   def members
@@ -37,10 +37,20 @@ class PagesController < ApplicationController
                            .distinct
                            .order(Arel.sql("RANDOM()"))
                            .first
+    @people_map_data = Rails.cache.fetch(["people_map", User.maximum(:updated_at)]) do
+      helpers.count_geographic_occurrences_of_users(@users)
+    end
+    @author_growth = Rails.cache.fetch(["author_growth", Publication.maximum(:updated_at)]) do
+      helpers.count_first_authors_over_time(@publications, Time.new.year - 1)
+    end
   end
 
   def show_member
-    @user = User.includes(:organisation, :platforms, profile_picture_attachment: :blob).find(params[:id])
+    @user = User.includes(:organisation, :platforms, :photos, profile_picture_attachment: :blob).find(params[:id])
+    @member_publications = @user.publications.includes(:users, :journal, pdf_attachment: :blob).order('publication_year DESC, created_at DESC').page(params[:page]).per(20)
+    @member_map_data = Rails.cache.fetch(["member_map", params[:id], Publication.maximum(:updated_at)]) do
+      helpers.count_geographic_occurrences_of_publications_from_user(@user)
+    end
   rescue
     redirect_to root_path
   end
@@ -101,6 +111,9 @@ class PagesController < ApplicationController
   end
 
   def member_research_summary
-    render partial: 'research_summary', locals: { user: User.find(params[:id]) }
+    cached = Rails.cache.fetch(["member_research_summary", params[:id], Publication.maximum(:updated_at)]) do
+      render_to_string partial: 'research_summary', locals: { user: User.find(params[:id]) }
+    end
+    render html: cached.html_safe
   end
 end

--- a/app/views/pages/_newsfeed.html.erb
+++ b/app/views/pages/_newsfeed.html.erb
@@ -29,7 +29,7 @@
       <div class="mt-1 d-flex align-items-center gap-1">
         <span class="badge border text-secondary" style="font-size: 0.7em; font-weight: normal;"><%= publication.publication_format.titleize %></span>
         <% if publication.open_access? %>
-          <span class="badge border border-success text-success" style="font-size: 0.7em; font-weight: normal;">Open Access</span>
+          <span class="badge border" style="font-size: 0.7em; font-weight: normal; color: #f68212; border-color: #f68212 !important;"><%= image_tag "open_access.svg", style: "height: 0.9em; vertical-align: -0.1em;", alt: "" %> Open Access</span>
         <% end %>
         <% if publication.DOI.present? %>
           <%= link_to publication.doi_url, class: "text-muted ms-auto", style: "font-size: 0.85em; text-decoration: none;" do %>

--- a/app/views/pages/members.html.erb
+++ b/app/views/pages/members.html.erb
@@ -35,27 +35,29 @@
       </div>
     </div>
 
+    <% cache ["people_map_card", User.maximum(:updated_at)] do %>
     <div class="card">
       <div class="card-header"><strong>People Locations</strong></div>
       <div class="card-body p-1">
-        <% data = count_geographic_occurrences_of_users(@users) %>
         <%= render partial: 'shared/world_map', locals: { title: 'Sites',
-                                                          data: data,
+                                                          data: @people_map_data,
                                                           height: 200 } %>
       </div>
     </div>
+    <% end %>
 
+    <% cache ["author_growth_card", Publication.maximum(:updated_at)] do %>
     <div class="card">
       <div class="card-header"><strong>Growth of Mesophotic Community</strong></div>
       <div class="card-body p-1">
-        <% cats, occurs = count_first_authors_over_time(@publications, Time.new.year - 1) %>
         <%= render partial: 'shared/area_graph',
                    locals: { title: 'Publications',
-                             categories: cats,
-                             occurrences: occurs,
+                             categories: @author_growth[0],
+                             occurrences: @author_growth[1],
                              height: 200,
                              unit: "Unique first-authors" } %>
       </div>
     </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/pages/show_member.html.erb
+++ b/app/views/pages/show_member.html.erb
@@ -45,13 +45,15 @@
 
     <% if @user.publications.count > 0 %>
       <div class="card">
-        <div class="card-header"><strong>Publications</strong></div>
+        <div class="card-header"><strong>Publications</strong> <small class="text-muted">(<%= @user.publications.count %>)</small></div>
         <div class="card-body" style="background-color: #f8f9fa;">
           <p class="p-2 rounded text-muted" style="background-color: #e8f4fd; font-size: 0.85em;">
             Only publications relevant to mesophotic reefs are indexed.
           </p>
+          <%= paginate @member_publications %>
           <%= render partial: 'pages/newsfeed',
-                     locals: { publications: @user.publications.includes(:users, :journal, pdf_attachment: :blob).order('publication_year DESC, created_at DESC') } %>
+                     locals: { publications: @member_publications } %>
+          <%= paginate @member_publications %>
         </div>
       </div>
     <% end %>
@@ -59,15 +61,16 @@
 
   <div class="col-sm-4">
     <% if @user.publications.count > 0 %>
+      <% cache ["member_map_card", @user, Publication.maximum(:updated_at)] do %>
       <div class="card">
         <div class="card-header"><strong>Locations</strong></div>
         <div class="card-body p-1">
-          <% data = count_geographic_occurrences_of_publications_from_user(@user) %>
           <%= render partial: 'shared/world_map', locals: { title: 'Locations',
-                                                            data: data,
+                                                            data: @member_map_data,
                                                             height: 200 } %>
         </div>
       </div>
+      <% end %>
     <% end %>
 
     <% if @user.publications.count > 0 %>
@@ -80,6 +83,7 @@
     <% end %>
 
     <% if @user.platforms.count > 0 %>
+      <% cache ["member_platforms", @user] do %>
       <div class="card">
         <div class="card-header"><strong>Research Platforms</strong></div>
         <div class="card-body">
@@ -89,9 +93,11 @@
           <% end %>
         </div>
       </div>
+      <% end %>
     <% end %>
 
     <% if @user.photos.count > 0 %>
+      <% cache ["member_photos", @user] do %>
       <div class="card">
         <div class="card-header"><strong>Photographs</strong></div>
         <div class="card-body">
@@ -105,6 +111,7 @@
           <% end %>
         </div>
       </div>
+      <% end %>
     <% end %>
 
     <% if @user.publications.count > 0 %>

--- a/app/views/photos/_photo.html.erb
+++ b/app/views/photos/_photo.html.erb
@@ -1,6 +1,8 @@
+<% cache photo do %>
 <div style="aspect-ratio: 3/2; overflow: hidden; background-color: #f0f1f3;">
   <%= link_to photo_path(photo) do %>
     <%= image_tag photo.image.variant(resize: "340x227^", crop: "340x227+0+0"),
                   style: "width: 100%; height: 100%; object-fit: cover;" %>
   <% end %>
 </div>
+<% end %>

--- a/app/views/summary/_show.html.erb
+++ b/app/views/summary/_show.html.erb
@@ -45,19 +45,22 @@
       </div>
     <% end %>
 
-    <% if object.try(:photos) && object.photos.showcases_location.count > 0 %>
+    <% location_photos = object.try(:photos) ? object.photos.showcases_location.includes(image_attachment: :blob) : [] %>
+    <% if location_photos.any? %>
       <div class="card">
         <div class="card-header">
           <strong>Photographs</strong> (from the field)
         </div>
         <div class="card-body">
-        <% object.photos.showcases_location.each do |photo| %>
+        <% location_photos.each do |photo| %>
+          <% cache photo do %>
           <div style="aspect-ratio: 4/3; overflow: hidden; background-color: #f0f1f3; margin-bottom: 0.5rem;">
             <%= link_to photo_path(photo) do %>
               <%= image_tag photo.image.variant(resize: "400x300^", crop: "400x300+0+0"),
                             style: "width: 100%; height: 100%; object-fit: cover;" %>
             <% end %>
           </div>
+          <% end %>
         <% end %>
         </div>
       </div>


### PR DESCRIPTION
## Summary

**Server-side caching:**
- World map endpoint — cached keyed on model/IDs/Publication.updated_at
- Member show page map data — cached in controller
- Member research summary — cached keyed on user/Publication.updated_at
- People page map + author growth chart — moved queries from view to controller, cached

**Fragment caching:**
- Member show page: map card, platforms card, photos card (individually cached, skipping render_async sections)
- People page: map card, author growth chart card
- Media gallery: per-photo card caching
- Summary page location photos: per-photo caching with eager loaded blobs

**Eager loading:**
- Media gallery: `image_attachment: :blob` on photos
- Member show: added `:photos` to includes
- Summary page photos: `image_attachment: :blob`

**Other:**
- Member publications paginated (20 per page) with count in header
- Open Access badge: official PLoS SVG logo with orange branding (`#f68212`)

## Test plan

- [x] All 162 tests pass
- [x] Home page: Open Access logo renders in publication badges
- [x] Member show: publications paginated, sidebar sections all render
- [x] People page: map and growth chart render
- [x] Media gallery: photos render with placeholders
- [x] Summary pages: photos render, keywords/researchers/summary load
- [x] With `rails dev:cache`: cached pages load significantly faster on second visit