### PR TITLE
Restyle publications index: newsfeed layout, eager loading, sidebar caching

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -21,7 +21,7 @@ class PublicationsController < ApplicationController
         .search(params[:search], params[:search_params], is_editor_or_admin)
 
       format.html {
-        @publications = @publications.page(params[:page]).per(is_editor_or_admin ? 100 : 20)
+        @publications = @publications.includes(:users, :journal, pdf_attachment: :blob).page(params[:page]).per(is_editor_or_admin ? 100 : 20)
 
         unless current_user.try(:editor_or_admin?) || params[:search_term].present?
           @locations = Location

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -48,11 +48,11 @@
       <% end %>
     </table>
   <% else %>
-    <table class="table table-sm table-striped">
-      <% @publications.each do |publication| %>
-        <%= render publication %>
-      <% end %>
-    </table>
+    <div class="card">
+      <div class="card-body" style="background-color: #f8f9fa;">
+        <%= render partial: 'pages/newsfeed', locals: { publications: @publications } %>
+      </div>
+    </div>
   <% end %>
 
   <div class="d-flex align-items-center gap-2">
@@ -74,6 +74,7 @@
         <%= render_async world_map_path(key: "publications_index", model: Location, ids: @locations, height: 150) %>
       </div>
     </div>
+    <% cache ["publications_sidebar_focus", Publication.maximum(:updated_at)] do %>
     <div class="card">
       <div class="card-header"><strong>Research Focus</strong></div>
       <div class="card-body" align="center">
@@ -85,6 +86,8 @@
                              unit: "Publications" } %>
       </div>
     </div>
+    <% end %>
+    <% cache ["publications_sidebar_fields", Publication.maximum(:updated_at)] do %>
     <div class="card">
       <div class="card-header"><strong>Fields</strong></div>
       <div class="card-body" align="center">
@@ -96,6 +99,8 @@
                              unit: "Publications" } %>
       </div>
     </div>
+    <% end %>
+    <% cache ["publications_sidebar_platforms", Publication.maximum(:updated_at)] do %>
     <div class="card">
       <div class="card-header"><strong>Research Platforms</strong></div>
       <div class="card-body" align="center">
@@ -107,6 +112,7 @@
                              unit: "Publications" } %>
       </div>
     </div>
+    <% end %>
   </div>
 <% end %>
 </div>


### PR DESCRIPTION
## Summary

- **Publications list** (non-editor view) — replaced old table layout with the newsfeed card layout (matching home page, summary pages, member profiles)
- **Eager loading** — added `includes(:users, :journal, pdf_attachment: :blob)` to publications index query
- **Sidebar chart caching** — Research Focus, Fields, and Platforms bar graphs fragment cached keyed on `Publication.maximum(:updated_at)`
- Editor view unchanged (uses separate `_publication_validation` partial)

## Test plan

- [x] All 162 tests pass
- [x] Publications index: newsfeed layout with thumbnails, tags, DOI links
- [x] Search results: same newsfeed layout
- [x] Sidebar charts render (Focus, Fields, Platforms)
- [x] Editor mode: validation table unchanged