### PR TITLE
Move locations dropdown above map card

### DIFF
--- a/app/views/admin/posts/dashboard.html.erb
+++ b/app/views/admin/posts/dashboard.html.erb
@@ -1,9 +1,27 @@
 <% title("Posts Dashboard") %>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", nil]] } %>
-<h3 class="page-title">Posts <small>Dashboard</small></h3>
-<hr/>
-<div class="row">
-  <div class="col-sm-4">Published: <%= link_to "#{pluralize(@published_post_count, 'post')}", admin_posts_path %></div>
-  <div class="col-sm-4">Drafts: <%= link_to "#{pluralize(@draft_post_count, 'draft')}", drafts_admin_posts_path %></div>
-  <div class="col-sm-4"><%= link_to "New post", new_admin_post_path %></div>
+<h3 class="page-title">Posts</h3>
+
+<div class="d-flex gap-3 mb-3">
+  <div class="card flex-fill">
+    <div class="card-body text-center">
+      <div style="font-size: 1.5em; font-weight: bold;"><%= @published_post_count %></div>
+      <small class="text-muted">Published</small>
+      <div class="mt-2"><%= link_to "View", admin_posts_path, class: "btn btn-sm btn-outline-secondary" %></div>
+    </div>
+  </div>
+  <div class="card flex-fill">
+    <div class="card-body text-center">
+      <div style="font-size: 1.5em; font-weight: bold;"><%= @draft_post_count %></div>
+      <small class="text-muted">Drafts</small>
+      <div class="mt-2"><%= link_to "View", drafts_admin_posts_path, class: "btn btn-sm btn-outline-secondary" %></div>
+    </div>
+  </div>
+  <div class="card flex-fill">
+    <div class="card-body text-center d-flex flex-column justify-content-center">
+      <%= link_to new_admin_post_path, class: "btn btn-primary" do %>
+        <i class="bi bi-plus-lg"></i> New Post
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/admin/posts/dashboard.html.erb
+++ b/app/views/admin/posts/dashboard.html.erb
@@ -1,6 +1,6 @@
 <% title("Posts Dashboard") %>
-<h3 class="page-title">Posts <small>Dashboard</small></h3>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", nil]] } %>
+<h3 class="page-title">Posts <small>Dashboard</small></h3>
 <hr/>
 <div class="row">
   <div class="col-sm-4">Published: <%= link_to "#{pluralize(@published_post_count, 'post')}", admin_posts_path %></div>

--- a/app/views/admin/posts/drafts.html.erb
+++ b/app/views/admin/posts/drafts.html.erb
@@ -1,6 +1,6 @@
 <% title("Post Drafts") %>
-<h3 class="page-title">Posts <small>Drafts</small></h3>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["Drafts", nil]] } %>
+<h3 class="page-title">Posts <small>Drafts</small></h3>
 <hr/>
 
 <p class="pagination-summary"><%= page_entries_info @posts %></p>

--- a/app/views/admin/posts/drafts.html.erb
+++ b/app/views/admin/posts/drafts.html.erb
@@ -1,23 +1,33 @@
 <% title("Post Drafts") %>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["Drafts", nil]] } %>
 <h3 class="page-title">Posts <small>Drafts</small></h3>
-<hr/>
 
-<p class="pagination-summary"><%= page_entries_info @posts %></p>
 <%= paginate @posts %>
+<div class="mb-3" style="margin-top: -0.5rem;">
+  <small class="text-muted"><%= page_entries_info @posts %></small>
+</div>
 
-<hr/>
+<div class="card">
+  <div class="card-body" style="background-color: #f8f9fa;">
+    <% @posts.each do |post| %>
+      <div class="d-flex justify-content-between align-items-start<%= ' mb-3 pb-3 border-bottom' unless post == @posts.last %>">
+        <div>
+          <strong><%= link_to post.title, edit_admin_post_path(post.slug), class: "newsfeed-title" %></strong>
+          <span class="badge bg-warning text-dark" style="font-size: 0.7em;">Draft</span>
+          <br>
+          <small class="text-muted"><%= post.category %> · Updated <%= time_ago_in_words(post.updated_at) %> ago</small>
+        </div>
+        <div class="d-flex gap-2">
+          <%= link_to edit_admin_post_path(post.slug), class: "text-muted icon-btn" do %>
+            <i class="bi bi-pencil"></i><i class="bi bi-pencil-fill"></i>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
 
-<ul>
-  <% @posts.each do |post| %>
-  <li class="margin-md-down">
-    <i class="bi bi-arrow-right-circle small"></i>&nbsp;&nbsp;
-    <%= link_to post.title, edit_admin_post_path(post.slug) %> <br/>
-    <small class="x-small-text">about <%= time_ago_in_words(post.updated_at) %> ago</small>
-  </li>
-  <% end %>
-</ul>
-
-<hr/>
-
+<div class="mt-2 mb-2">
+  <small class="text-muted"><%= page_entries_info @posts %></small>
+</div>
 <%= paginate @posts %>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -1,6 +1,6 @@
 <% title("Edit #{@post.title}") %>
-<h3 class="page-title">Edit Post <small><%= @post.title %></small></h3>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], [@post.title, nil]] } %>
+<h3 class="page-title">Edit Post <small><%= @post.title %></small></h3>
 <hr/>
 
 <%= render 'form' %>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -1,8 +1,11 @@
 <% title("Edit #{@post.title}") %>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], [@post.title, nil]] } %>
 <h3 class="page-title">Edit Post <small><%= @post.title %></small></h3>
-<hr/>
 
 <%= render 'form' %>
-<hr/>
-<%= link_to "<i class='bi bi-dash-square'></i> Delete post".html_safe, admin_post_path(@post), method: :delete, data:{confirm: "Are you sure?"}, class: "btn btn-small btn-danger" %>
+
+<div class="mt-3">
+  <%= link_to admin_post_path(@post), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-outline-danger icon-btn" do %>
+    <i class="bi bi-trash"></i><i class="bi bi-trash-fill"></i> Delete Post
+  <% end %>
+</div>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,22 +1,35 @@
 <% title("Published Posts") %>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["Published", nil]] } %>
 <h3 class="page-title">Posts <small>Published</small></h3>
-<hr/>
 
-<p class="pagination-summary"><%= page_entries_info @posts %></p>
 <%= paginate @posts %>
+<div class="mb-3" style="margin-top: -0.5rem;">
+  <small class="text-muted"><%= page_entries_info @posts %></small>
+</div>
 
-<hr/>
+<div class="card">
+  <div class="card-body" style="background-color: #f8f9fa;">
+    <% @posts.each do |post| %>
+      <div class="d-flex justify-content-between align-items-start<%= ' mb-3 pb-3 border-bottom' unless post == @posts.last %>">
+        <div>
+          <strong><%= link_to post.title, edit_admin_post_path(post.slug), class: "newsfeed-title" %></strong>
+          <% if post.draft? %>
+            <span class="badge bg-warning text-dark" style="font-size: 0.7em;">Draft</span>
+          <% end %>
+          <br>
+          <small class="text-muted"><%= post.category %> · Updated <%= time_ago_in_words(post.updated_at) %> ago</small>
+        </div>
+        <div class="d-flex gap-2">
+          <%= link_to edit_admin_post_path(post.slug), class: "text-muted icon-btn" do %>
+            <i class="bi bi-pencil"></i><i class="bi bi-pencil-fill"></i>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>
 
-<ul class="bi">
-  <% @posts.each do |post| %>
-  <li class="margin-md-down">
-    <%= link_to post.title, edit_admin_post_path(post.slug) %><br/>
-    <small class="x-small-text">about <%= time_ago_in_words(post.updated_at) %> ago</small>
-  </li>
-  <% end %>
-</ul>
-
-<hr/>
-
+<div class="mt-2 mb-2">
+  <small class="text-muted"><%= page_entries_info @posts %></small>
+</div>
 <%= paginate @posts %>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,6 +1,6 @@
 <% title("Published Posts") %>
-<h3 class="page-title">Posts <small>Published</small></h3>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["Published", nil]] } %>
+<h3 class="page-title">Posts <small>Published</small></h3>
 <hr/>
 
 <p class="pagination-summary"><%= page_entries_info @posts %></p>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -1,6 +1,5 @@
 <% title("New Post") %>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["New", nil]] } %>
-<h3 class="page-title">Add a New Post</h3>
-<hr/>
+<h3 class="page-title">New Post</h3>
 
 <%= render 'form' %>

--- a/app/views/admin/posts/new.html.erb
+++ b/app/views/admin/posts/new.html.erb
@@ -1,6 +1,6 @@
 <% title("New Post") %>
-<h3 class="page-title">Add a New Post</h3>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], ["New", nil]] } %>
+<h3 class="page-title">Add a New Post</h3>
 <hr/>
 
 <%= render 'form' %>

--- a/app/views/admin/publications/dashboard.html.erb
+++ b/app/views/admin/publications/dashboard.html.erb
@@ -1,7 +1,6 @@
 <% title("Published Posts") %>
-<h3 class="page-title">Publications</h3>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Publications", nil]] } %>
-<hr/>
+<h3 class="page-title">Publications</h3>
 
 <div class="col-sm-12">
   <%= paginate @publications %>

--- a/app/views/admin/publications/index.html.erb
+++ b/app/views/admin/publications/index.html.erb
@@ -1,6 +1,6 @@
 <% title("Published Posts") %>
-<h3 class="page-title">Posts <small>Published</small></h3>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Publications", dashboard_admin_publications_path], ["All", nil]] } %>
+<h3 class="page-title">Posts <small>Published</small></h3>
 <hr/>
 
 <%= paginate @publications %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -2,21 +2,22 @@
        locals: {title: "Locations",
                 breadcrumbs: [["Locations", nil]] } %>
 
+<div class="mb-3">
+  <select onchange="window.location=this.value" class="fw-bold" style="width: auto; display: inline-block; border: none; background-color: #dfe3e7; padding: 2px 8px; border-radius: 4px;">
+    <option>Select a location</option>
+    <% @locations.each do |location| %>
+      <option value="<%= summary_path(model: "locations", id: location.id) %>">
+        <%= location.description %>
+      </option>
+    <% end %>
+  </select>
+</div>
+
 <div class="row">
   <div class="col-sm-8">
-    <div class="card mb-0">
-      <div class="card-header px-2" style="padding-top: 7px; padding-bottom: 7px;">
-        <select onchange="window.location=this.value" class="fw-bold" style="width: auto; display: inline-block; border: none; background-color: #dfe3e7; padding: 2px 8px; border-radius: 4px;">
-          <option>Select a location</option>
-          <% @locations.each do |location| %>
-            <option value="<%= summary_path(model: "locations", id: location.id) %>">
-              <%= location.description %>
-            </option>
-          <% end %>
-        </select>
-      </div>
-      <div class="card-body p-1" style="min-height: 358px;">
-        <%= render_async world_map_path(key: "locations_index", model: Location, ids: @locations.map(&:id).join(','), height: 350) %>
+    <div class="card mb-0 h-100">
+      <div class="card-body p-0">
+        <%= render_async world_map_path(key: "locations_index", model: Location, ids: @locations.map(&:id).join(','), height: 380) %>
       </div>
     </div>
   </div>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -16,7 +16,7 @@
 <div class="row">
   <div class="col-sm-8">
     <div class="card mb-0 h-100">
-      <div class="card-body p-0">
+      <div class="card-body p-0" style="min-height: 380px;">
         <%= render_async world_map_path(key: "locations_index", model: Location, ids: @locations.map(&:id).join(','), height: 380) %>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Moved the location dropdown picker from the map card header to its own section under the page title, matching the summary page layout.