### PR TITLE
Add page_entries_info, search relevance display, and snippet improvements

### DIFF
--- a/app/helpers/publications_helper.rb
+++ b/app/helpers/publications_helper.rb
@@ -4,10 +4,10 @@ module PublicationsHelper
     return "…" if contents.blank?
 
     start = [0, contents.downcase.index(search_term.downcase) || 0 - 300].max
-    snippet = contents.force_encoding("UTF-8")[start, 600]
+    snippet = contents.force_encoding("UTF-8")[start, 400]
                       .squish
                       .gsub(/(#{search_term})/i, '<strong>\1</strong>')
-    simple_format "…#{snippet}…"
+    "…#{snippet}…".html_safe
   end
 
   # Count occurrence of word in contents

--- a/app/views/admin/publications/dashboard.html.erb
+++ b/app/views/admin/publications/dashboard.html.erb
@@ -4,10 +4,12 @@
 
 <div class="col-sm-12">
   <%= paginate @publications %>
+  <div class="mb-3" style="margin-top: -0.5rem;"><small class="text-muted"><%= page_entries_info @publications %></small></div>
   <div class="card mt-2">
     <div class="card-body" style="background-color: #f8f9fa;">
       <%= render partial: 'pages/newsfeed', locals: { publications: @publications } %>
     </div>
   </div>
+  <div class="mt-2 mb-2"><small class="text-muted"><%= page_entries_info @publications %></small></div>
   <%= paginate @publications %>
 </div>

--- a/app/views/pages/_newsfeed.html.erb
+++ b/app/views/pages/_newsfeed.html.erb
@@ -1,43 +1,56 @@
 <% publications.each do |publication| %>
-  <div class="d-flex align-items-start<%= ' mb-3 pb-3 border-bottom' unless publication == publications.last %>">
-    <% cache publication do %>
-    <div class="flex-shrink-0" style="width: 60px;">
-      <% if publication.pdf.attached? %>
-        <%= link_to publication do %>
-          <%= image_tag publication.pdf.preview(resize: "60x84>"), style: "width: 60px; border-radius: 3px; box-shadow: 0 1px 3px rgba(0,0,0,0.15);" %>
-        <% end %>
-      <% else %>
-        <%= link_to publication do %>
-          <div class="d-flex align-items-center justify-content-center rounded" style="width: 60px; height: 84px; background-color: #f0f1f3;">
-            <i class="bi bi-file-earmark-text text-muted"></i>
-          </div>
-        <% end %>
-      <% end %>
-    </div>
-    <div class="flex-grow-1 ms-3">
-      <div>
-        <strong><%= link_to truncate(publication.title, length: 120), publication, class: "newsfeed-title" %></strong>
-      </div>
-      <div style="font-size: 0.9em;">
-        <%= format_authors(publication) %> (<%= publication.publication_year %>)
-      </div>
-      <% if publication.scientific_article? && publication.journal %>
-        <div class="text-muted" style="font-size: 0.9em;">
-          <em><%= publication.journal.name %></em>
-        </div>
-      <% end %>
-      <div class="mt-1 d-flex align-items-center gap-1">
-        <span class="badge border text-secondary" style="font-size: 0.7em; font-weight: normal;"><%= publication.publication_format.titleize %></span>
-        <% if publication.open_access? %>
-          <span class="badge border" style="font-size: 0.7em; font-weight: normal; color: #f68212; border-color: #f68212 !important;"><%= image_tag "open_access.svg", style: "height: 0.9em; vertical-align: -0.1em;", alt: "" %> Open Access</span>
-        <% end %>
-        <% if publication.DOI.present? %>
-          <%= link_to publication.doi_url, class: "text-muted ms-auto", style: "font-size: 0.85em; text-decoration: none;" do %>
-            <i class="bi bi-link-45deg"></i> DOI
+  <% show_relevance = params[:search].present? && publication.respond_to?(:relevance) && defined?(params[:search_params]) && Publication.should_show_relevance(params[:search_params][:search_fields]) %>
+  <div class="<%= 'mb-3 pb-3 border-bottom' unless publication == publications.last %>">
+    <div class="d-flex align-items-start">
+      <% cache publication do %>
+      <div class="flex-shrink-0" style="width: 60px;">
+        <% if publication.pdf.attached? %>
+          <%= link_to publication do %>
+            <%= image_tag publication.pdf.preview(resize: "60x84>"), style: "width: 60px; border-radius: 3px; box-shadow: 0 1px 3px rgba(0,0,0,0.15);" %>
+          <% end %>
+        <% else %>
+          <%= link_to publication do %>
+            <div class="d-flex align-items-center justify-content-center rounded" style="width: 60px; height: 84px; background-color: #f0f1f3;">
+              <i class="bi bi-file-earmark-text text-muted"></i>
+            </div>
           <% end %>
         <% end %>
       </div>
+      <div class="flex-grow-1 ms-3">
+        <div>
+          <strong><%= link_to truncate(publication.title, length: 120), publication, class: "newsfeed-title" %></strong>
+        </div>
+        <div style="font-size: 0.9em;">
+          <%= format_authors(publication) %> (<%= publication.publication_year %>)
+        </div>
+        <% if publication.scientific_article? && publication.journal %>
+          <div class="text-muted" style="font-size: 0.9em;">
+            <em><%= publication.journal.name %></em>
+          </div>
+        <% end %>
+        <div class="mt-1 d-flex align-items-center gap-1">
+          <span class="badge border text-secondary" style="font-size: 0.7em; font-weight: normal;"><%= publication.publication_format.titleize %></span>
+          <% if publication.open_access? %>
+            <span class="badge border" style="font-size: 0.7em; font-weight: normal; color: #f68212; border-color: #f68212 !important;"><%= image_tag "open_access.svg", style: "height: 0.9em; vertical-align: -0.1em;", alt: "" %> Open Access</span>
+          <% end %>
+          <% if publication.DOI.present? %>
+            <%= link_to publication.doi_url, class: "text-muted ms-auto", style: "font-size: 0.85em; text-decoration: none;" do %>
+              <i class="bi bi-link-45deg"></i> DOI
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+      <% end %>
     </div>
+    <% if show_relevance %>
+      <div class="d-flex align-items-start mt-2" style="font-size: 0.85em;">
+        <div class="flex-shrink-0 text-end text-muted" style="width: 60px;">
+          <strong style="font-size: 1.3em;"><%= publication.relevance %></strong>
+        </div>
+        <div class="flex-grow-1 ms-3 text-muted" style="border-left: 3px solid #dee2e6; padding-left: 0.75rem;">
+          <%= obtain_snippet((publication.relevance_content params[:search_params][:search_fields]), params[:search]) %>
+        </div>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/pages/media_gallery.html.erb
+++ b/app/views/pages/media_gallery.html.erb
@@ -12,7 +12,7 @@
     <br><br>
 
 	  <%= paginate @photos %>
-    <div class="mb-3" style="margin-top: -0.5rem;"><small class="text-muted"><%= @photos.total_count %> results</small></div>
+    <div class="mb-3" style="margin-top: -0.5rem;"><small class="text-muted"><%= page_entries_info @photos %></small></div>
 	  <table class="table table-striped">
 	    <tr>
 		    <% @photos.each_with_index do |photo, i| %>
@@ -21,7 +21,7 @@
 		    <% end %>
 		   </tr>
 	  </table>
-    <div class="mb-2"><small class="text-muted"><%= @photos.total_count %> results</small></div>
+    <div class="mb-2"><small class="text-muted"><%= page_entries_info @photos %></small></div>
     <%= paginate @photos %>
 	</div>
 </div>

--- a/app/views/pages/posts.html.erb
+++ b/app/views/pages/posts.html.erb
@@ -3,10 +3,12 @@
                 breadcrumbs: [["News", nil]] } %>
 
 <%= paginate @posts %>
+<div class="mb-3" style="margin-top: -0.5rem;"><small class="text-muted"><%= page_entries_info @posts %></small></div>
 <% @posts.each do |post| %>
   <% cache ["post_card", post] do %>
     <%= render partial: 'shared/post_summary',
                locals: {post: post } %>
   <% end %>
 <% end %>
+<div class="mt-2 mb-2"><small class="text-muted"><%= page_entries_info @posts %></small></div>
 <%= paginate @posts %>

--- a/app/views/pages/show_member.html.erb
+++ b/app/views/pages/show_member.html.erb
@@ -62,8 +62,10 @@
             Only publications relevant to mesophotic reefs are indexed.
           </p>
           <%= paginate @member_publications %>
+          <div class="mb-3" style="margin-top: -0.5rem;"><small class="text-muted"><%= page_entries_info @member_publications %></small></div>
           <%= render partial: 'pages/newsfeed',
                      locals: { publications: @member_publications } %>
+          <div class="mt-2 mb-2"><small class="text-muted"><%= page_entries_info @member_publications %></small></div>
           <%= paginate @member_publications %>
         </div>
       </div>

--- a/app/views/photos/index.html.erb
+++ b/app/views/photos/index.html.erb
@@ -5,6 +5,7 @@
 <div class="row">
   <div class="col-sm-8">
 	  <%= paginate @photos %>
+    <div class="mb-3" style="margin-top: -0.5rem;"><small class="text-muted"><%= page_entries_info @photos %></small></div>
 
 	  <table class="table table-striped">
 	    <tr>
@@ -14,6 +15,7 @@
 		    <% end %>
 		   </tr>
 	  </table>
+    <div class="mt-2 mb-2"><small class="text-muted"><%= page_entries_info @photos %></small></div>
     <%= paginate @photos %>
 
 	  <% if current_user.try(:editor_or_admin?) %>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -27,7 +27,7 @@
   <div class="mb-3">
     <%= paginate @publications %>
     <div style="margin-top: -0.5rem;">
-      <small class="text-muted"><%= @publications.total_count %> results</small>
+      <small class="text-muted">Displaying publications <b><%= @publications.offset_value + 1 %>&ndash;<%= @publications.offset_value + @publications.length %></b> of <b><%= @publications.total_count %></b> in total</small>
       <small>&bullet; <%= link_to "Download as CSV", publications_path(format: :csv, params: params.permit!) %></small>
       <% if current_user.try(:editor_or_admin?) %>
         <small class="text-muted">· sorted by ID desc</small>
@@ -59,7 +59,7 @@
 
   <div>
     <div class="mb-2">
-      <small class="text-muted"><%= @publications.total_count %> results</small>
+      <small class="text-muted">Displaying publications <b><%= @publications.offset_value + 1 %>&ndash;<%= @publications.offset_value + @publications.length %></b> of <b><%= @publications.total_count %></b> in total</small>
       <small>&bullet; <%= link_to "Download as CSV", publications_path(format: :csv, params: params.permit!) %></small>
     </div>
     <%= paginate @publications %>

--- a/app/views/species/_show.html.erb
+++ b/app/views/species/_show.html.erb
@@ -8,7 +8,7 @@
   <div class="col-sm-8">
     <%= paginate publications %>
     <div class="mb-3" style="margin-top: -0.5rem;">
-      <small class="text-muted"><%= publications.total_count %> results</small>
+      <small class="text-muted"><%= page_entries_info publications %></small>
       <small>&bullet; <%= link_to "Download as CSV", summary_path(title.downcase, object.id, format: :csv) %></small>
     </div>
 
@@ -20,7 +20,7 @@
     </div>
 
     <div class="mt-2 mb-2">
-      <small class="text-muted"><%= publications.total_count %> results</small>
+      <small class="text-muted"><%= page_entries_info publications %></small>
       <small>&bullet; <%= link_to "Download as CSV", summary_path(title.downcase, object.id, format: :csv) %></small>
     </div>
     <%= paginate publications %>

--- a/app/views/summary/_show.html.erb
+++ b/app/views/summary/_show.html.erb
@@ -16,7 +16,7 @@
 
     <%= paginate publications %>
     <div class="mb-3" style="margin-top: -0.5rem;">
-      <small class="text-muted"><%= publications.total_count %> results</small>
+      <small class="text-muted"><%= page_entries_info publications %></small>
       <small>&bullet; <%= link_to "Download as CSV", summary_path(title.downcase, object.id, format: :csv) %></small>
     </div>
 
@@ -28,7 +28,7 @@
 	</div>
 
     <div class="mt-2 mb-2">
-      <small class="text-muted"><%= publications.total_count %> results</small>
+      <small class="text-muted"><%= page_entries_info publications %></small>
       <small>&bullet; <%= link_to "Download as CSV", summary_path(title.downcase, object.id, format: :csv) %></small>
     </div>
     <%= paginate publications %>


### PR DESCRIPTION
## Summary

Stacked on #180 (locations/admin UI changes).

- **page_entries_info** added to all pagination controls (summary, species, photos, media gallery, member profile, admin publications, admin posts, news posts)
- **Publications index** uses manual page info (same format) due to Kaminari `.size` bug with relevance scope
- **Search relevance** restored in newsfeed layout — occurrence count on left, highlighted snippet on right, grouped with publication via shared border-bottom container
- **Snippet** reduced from 600 to 400 chars, replaced `simple_format` (extra `<p>` tag) with `.html_safe`

## Test plan

- [x] All 167 tests pass
- [x] Pagination shows "Displaying X - Y of Z in total" on all pages
- [x] Search results show relevance count and highlighted snippet
- [x] No HTML tags visible in snippet text