### PR TITLE
Stream CSV exports

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -54,7 +54,9 @@ class PublicationsController < ApplicationController
 
       format.csv {
         authenticate_user!
-        send_data @publications.reorder(:id).csv
+        headers["Content-Disposition"] = "attachment; filename=\"publications.csv\""
+        headers["Content-Type"] = "text/csv"
+        self.response_body = Publication.csv_enumerator(@publications.reorder(:id))
       }
     end
   end

--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -10,7 +10,9 @@ class SummaryController < ApplicationController
 
       format.csv {
         authenticate_user!
-        send_data publications.reorder(:id).csv, filename: "#{@model} #{@object.id}, #{@object.description}.csv"
+        headers["Content-Disposition"] = "attachment; filename=\"#{@model} #{@object.id}, #{@object.description}.csv\""
+        headers["Content-Type"] = "text/csv"
+        self.response_body = Publication.csv_enumerator(publications.reorder(:id))
       }
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,23 +28,34 @@ module ApplicationHelper
   end
 
   def word_association
-    [Platform, Field, Focusgroup, Location].reduce({}) { |r, model|
-      r.merge model.model_name.plural => model.all.reduce({}) { |r, m|
-        words = m.short_description.split(';').map(&:strip) rescue []
-        r.merge words.reduce({}) { |r, w|
-          r.merge w.downcase => m.id
+    cache_key = [
+      "word_association",
+      Platform.maximum(:updated_at),
+      Field.maximum(:updated_at),
+      Focusgroup.maximum(:updated_at),
+      Location.maximum(:updated_at)
+    ]
+    Rails.cache.fetch(cache_key) do
+      [Platform, Field, Focusgroup, Location].reduce({}) { |r, model|
+        r.merge model.model_name.plural => model.all.reduce({}) { |r, m|
+          words = m.short_description.split(';').map(&:strip) rescue []
+          r.merge words.reduce({}) { |r, w|
+            r.merge w.downcase => m.id
+          }
         }
       }
-    }
+    end
   end
 
   def species_association
-    Species.all.reduce([]) { |r, s|
-      words = s.short_description.split(';').map(&:strip) rescue []
-      r << words.reduce({}) { |r, w|
-        r.merge w.downcase => s.id
+    Rails.cache.fetch(["species_association", Species.maximum(:updated_at)]) do
+      Species.all.reduce([]) { |r, s|
+        words = s.short_description.split(';').map(&:strip) rescue []
+        r << words.reduce({}) { |r, w|
+          r.merge w.downcase => s.id
+        }
       }
-    }
+    end
   end
 
   def linkify content

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -296,6 +296,41 @@ class Publication < ApplicationRecord
     end
   }
 
+  def self.csv_association_data
+    validated = Publication.validated.map(&:id)
+    fields = Field
+      .select("publications.id, GROUP_CONCAT(description, '; ') AS description")
+      .joins(:publications)
+      .group("publications.id")
+      .reduce({}) { |result, a| result.update(a.id => a.description) }
+    focusgroups = Focusgroup
+      .select("publications.id, GROUP_CONCAT(description, '; ') AS description")
+      .joins(:publications)
+      .group("publications.id")
+      .reduce({}) { |result, a| result.update(a.id => a.description) }
+    platforms = Platform
+      .select("publications.id, GROUP_CONCAT(description, '; ') AS description")
+      .joins(:publications)
+      .group("publications.id")
+      .reduce({}) { |result, a| result.update(a.id => a.description) }
+    locations = Location
+      .select("publications.id, GROUP_CONCAT(description, '; ') AS description")
+      .joins(:publications)
+      .group("publications.id")
+      .reduce({}) { |result, a| result.update(a.id => a.description) }
+    [validated, fields, focusgroups, platforms, locations]
+  end
+
+  def self.csv_enumerator(scope)
+    Enumerator.new do |yielder|
+      yielder << CSV.generate_line(csv_header)
+      validated, fields, focusgroups, platforms, locations = csv_association_data
+      scope.csv_rows.find_each(batch_size: 100) do |publication|
+        yielder << CSV.generate_line(csv_row(publication, validated, fields, focusgroups, platforms, locations))
+      end
+    end
+  end
+
   scope :csv_rows, -> {
     select(
       """

--- a/docs/superpowers/plans/2026-04-03-performance-4-5-7.md
+++ b/docs/superpowers/plans/2026-04-03-performance-4-5-7.md
@@ -1,0 +1,499 @@
+# Performance Tasks 4, 5, 7 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cache word/species associations, stream CSV exports, and fix ResizeObserver leak in charts.js.
+
+**Architecture:** Three independent fixes delivered as stacked jj bookmarks with PRs against main. Each bookmark builds on the previous so they can be reviewed and merged sequentially.
+
+**Tech Stack:** Rails 6.1, Ruby 3.2, Minitest, jj
+
+---
+
+## Task 1: Cache word_association and species_association (Performance #4)
+
+**Bookmark:** `ryan/perf-memoize-associations`
+
+**Files:**
+- Modify: `app/helpers/application_helper.rb:30-48`
+- Modify: `test/helpers/application_helper_test.rb:49-58`
+
+The `word_association` and `species_association` helpers load every Platform, Field, Focusgroup, Location, and Species record on every call. They're called from `linkify` (publication show page) and `_wordcloud.html.erb` (summary/site/keyword pages). Cache the results with `Rails.cache.fetch` keyed on the max `updated_at` across the relevant tables.
+
+- [ ] **Step 1: Update existing tests to verify caching behaviour**
+
+In `test/helpers/application_helper_test.rb`, replace the two existing tests:
+
+```ruby
+test "word_association returns hash of model associations" do
+  result = word_association
+  assert result.is_a?(Hash)
+  assert_includes result.keys, "platforms"
+  assert_includes result.keys, "fields"
+  assert_includes result.keys, "focusgroups"
+  assert_includes result.keys, "locations"
+end
+
+test "species_association returns array of species data" do
+  result = species_association
+  assert result.is_a?(Array)
+end
+
+test "word_association returns same result on second call (cached)" do
+  first = word_association
+  second = word_association
+  assert_equal first, second
+end
+
+test "species_association returns same result on second call (cached)" do
+  first = species_association
+  second = species_association
+  assert_equal first, second
+end
+```
+
+- [ ] **Step 2: Run tests to verify they pass with current code**
+
+Run: `rails test test/helpers/application_helper_test.rb -v`
+Expected: All pass (the new tests just check return values, which the uncached version also satisfies).
+
+- [ ] **Step 3: Add caching to word_association and species_association**
+
+In `app/helpers/application_helper.rb`, replace lines 30–48:
+
+```ruby
+def word_association
+  cache_key = [
+    "word_association",
+    Platform.maximum(:updated_at),
+    Field.maximum(:updated_at),
+    Focusgroup.maximum(:updated_at),
+    Location.maximum(:updated_at)
+  ]
+  Rails.cache.fetch(cache_key) do
+    [Platform, Field, Focusgroup, Location].reduce({}) { |r, model|
+      r.merge model.model_name.plural => model.all.reduce({}) { |r, m|
+        words = m.short_description.split(';').map(&:strip) rescue []
+        r.merge words.reduce({}) { |r, w|
+          r.merge w.downcase => m.id
+        }
+      }
+    }
+  end
+end
+
+def species_association
+  Rails.cache.fetch(["species_association", Species.maximum(:updated_at)]) do
+    Species.all.reduce([]) { |r, s|
+      words = s.short_description.split(';').map(&:strip) rescue []
+      r << words.reduce({}) { |r, w|
+        r.merge w.downcase => s.id
+      }
+    }
+  end
+end
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `rails test test/helpers/application_helper_test.rb -v`
+Expected: All pass.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `rails test`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+jj new
+jj bookmark create ryan/perf-memoize-associations
+jj describe -m 'Cache word_association and species_association with Rails.cache.fetch'
+```
+
+- [ ] **Step 7: Push and create PR**
+
+```bash
+jj git push --bookmark ryan/perf-memoize-associations
+gh pr create --title "Cache word/species associations" --body "$(cat <<'EOF'
+## Summary
+- Cache `word_association` and `species_association` helpers with `Rails.cache.fetch`
+- Keyed on `maximum(:updated_at)` across relevant tables — auto-invalidates when data changes
+- Eliminates 5 full-table loads per publication show page and per word cloud render
+
+## Test plan
+- [ ] Visit a publication show page — abstract links should still work
+- [ ] Visit a summary page with word cloud — words should still be clickable
+- [ ] Update a Platform/Field/Focusgroup/Location/Species in admin — verify cache invalidates
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 2: Stream CSV exports (Performance #5)
+
+**Bookmark:** `ryan/perf-csv-streaming` (stacked on `ryan/perf-memoize-associations`)
+
+**Files:**
+- Modify: `app/models/publication.rb:267-297`
+- Modify: `app/controllers/publications_controller.rb:55-58`
+- Modify: `app/controllers/summary_controller.rb:11-14`
+- Modify: `test/controllers/publications_controller_test.rb:80-84`
+
+The current `csv` scope builds the entire CSV string in memory with `CSV.generate`. Switch to streaming via `ActionController::Live` isn't needed — Rails `send_data` vs streaming. The simplest approach: convert the scope to return an `Enumerator` and use `response.stream` in the controller. However, on Rails 6.1 with Puma, `ActionController::Live` can be tricky. The safer approach is to keep `send_data` but build the CSV with `CSV.generate` line-by-line using an Enumerator that yields rows, avoiding loading all association hashes at once.
+
+Actually, the main memory issue is the 4 association hashes (fields, focusgroups, platforms, locations) built via `GROUP_CONCAT` + `reduce`. These are already efficient — they're single queries returning one row per publication. The real cost is the CSV string itself for large exports. Let's use `ActionController::Live` with `response.stream.write` to send rows as they're generated.
+
+- [ ] **Step 1: Extract CSV row generation from scope into class methods**
+
+In `app/models/publication.rb`, add a new class method alongside the existing `csv` scope. Replace the `csv` scope (lines 267-297) with:
+
+```ruby
+scope :csv, -> (**options) {
+  CSV.generate(**options) do |csv|
+    csv << csv_header
+    csv_association_data.then do |validated, fields, focusgroups, platforms, locations|
+      for publication in csv_rows
+        csv << csv_row(publication, validated, fields, focusgroups, platforms, locations)
+      end
+    end
+  end
+}
+
+def self.csv_association_data
+  validated = Publication.validated.map(&:id)
+  fields = Field
+    .select("publications.id, GROUP_CONCAT(description, '; ') AS description")
+    .joins(:publications)
+    .group("publications.id")
+    .reduce({}) { |result, a| result.update(a.id => a.description) }
+  focusgroups = Focusgroup
+    .select("publications.id, GROUP_CONCAT(description, '; ') AS description")
+    .joins(:publications)
+    .group("publications.id")
+    .reduce({}) { |result, a| result.update(a.id => a.description) }
+  platforms = Platform
+    .select("publications.id, GROUP_CONCAT(description, '; ') AS description")
+    .joins(:publications)
+    .group("publications.id")
+    .reduce({}) { |result, a| result.update(a.id => a.description) }
+  locations = Location
+    .select("publications.id, GROUP_CONCAT(description, '; ') AS description")
+    .joins(:publications)
+    .group("publications.id")
+    .reduce({}) { |result, a| result.update(a.id => a.description) }
+  [validated, fields, focusgroups, platforms, locations]
+end
+
+def self.csv_enumerator(scope)
+  Enumerator.new do |yielder|
+    yielder << CSV.generate_line(csv_header)
+    validated, fields, focusgroups, platforms, locations = csv_association_data
+    scope.csv_rows.find_each(batch_size: 100) do |publication|
+      yielder << CSV.generate_line(csv_row(publication, validated, fields, focusgroups, platforms, locations))
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Update controllers to stream CSV**
+
+In `app/controllers/publications_controller.rb`, replace the CSV format block:
+
+```ruby
+format.csv {
+  authenticate_user!
+  headers["Content-Disposition"] = "attachment; filename=\"publications.csv\""
+  headers["Content-Type"] = "text/csv"
+  self.response_body = Publication.csv_enumerator(@publications.reorder(:id))
+}
+```
+
+In `app/controllers/summary_controller.rb`, replace the CSV format block:
+
+```ruby
+format.csv {
+  authenticate_user!
+  headers["Content-Disposition"] = "attachment; filename=\"#{@model} #{@object.id}, #{@object.description}.csv\""
+  headers["Content-Type"] = "text/csv"
+  self.response_body = Publication.csv_enumerator(publications.reorder(:id))
+}
+```
+
+- [ ] **Step 3: Run existing CSV test**
+
+Run: `rails test test/controllers/publications_controller_test.rb -v`
+Expected: Both CSV tests pass (authenticated returns success, unauthenticated returns 401).
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `rails test`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+jj new
+jj bookmark create ryan/perf-csv-streaming
+jj describe -m 'Stream CSV exports row-by-row instead of building entire string in memory'
+```
+
+- [ ] **Step 6: Push and create PR**
+
+```bash
+jj git push --bookmark ryan/perf-csv-streaming
+gh pr create --base main --title "Stream CSV exports" --body "$(cat <<'EOF'
+## Summary
+- CSV exports now stream row-by-row via `Enumerator` + `self.response_body`
+- Association lookup hashes (fields, focusgroups, platforms, locations) still loaded upfront (4 efficient queries)
+- Rows generated and sent one at a time via `find_each(batch_size: 100)` — constant memory regardless of export size
+- Existing `csv` scope preserved for backward compatibility
+
+## Test plan
+- [ ] Sign in, go to publications index, click "Download as CSV" — file downloads correctly
+- [ ] Sign in, go to a species/location/etc summary page, click "Download as CSV" — file downloads correctly
+- [ ] Verify CSV content matches expected columns and data
+- [ ] Check server memory during a large export doesn't spike
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 3: Fix ResizeObserver leak in charts.js (Performance #7)
+
+**Bookmark:** `ryan/perf-resize-observer-cleanup` (stacked on `ryan/perf-csv-streaming`)
+
+**Files:**
+- Modify: `app/assets/javascripts/charts.js:108-148`
+
+Word cloud charts create `ResizeObserver` instances that are never disconnected on Turbolinks navigation. Each page visit to a page with charts leaks observers. Fix by tracking observers and disconnecting them on `turbolinks:before-cache`.
+
+- [ ] **Step 1: Add observer tracking and cleanup**
+
+In `app/assets/javascripts/charts.js`, replace the entire file content:
+
+```javascript
+// Auto-initialize Highcharts, Highcharts Maps, and WordCloud2 from data attributes.
+// Works with both direct rendering and render_async injection (no inline scripts needed).
+
+(function() {
+  var resizeObservers = [];
+
+  function initAll(scope) {
+    var root = (scope && scope.target instanceof HTMLElement) ? scope.target : document;
+    root.querySelectorAll('[data-chart]:not([data-chart-init])').forEach(initChart);
+    root.querySelectorAll('[data-wordcloud]:not([data-chart-init])').forEach(initWordcloud);
+  }
+
+  function cleanupObservers() {
+    resizeObservers.forEach(function(observer) { observer.disconnect(); });
+    resizeObservers = [];
+  }
+
+  // --- Highcharts ---
+
+  function initChart(el) {
+    var type = el.dataset.chart;
+    var init = chartTypes[type];
+    if (init) {
+      init(el);
+      el.dataset.chartInit = 'true';
+    }
+  }
+
+  function baseOpts(el) {
+    return {
+      title: { text: '' },
+      credits: { enabled: false },
+      legend: { enabled: false }
+    };
+  }
+
+  function simpleChart(el, chartType, opts) {
+    var categories = JSON.parse(el.dataset.categories);
+    var values = JSON.parse(el.dataset.values);
+    var unit = el.dataset.unit || '';
+    var config = baseOpts(el);
+    config.chart = { type: chartType };
+    config.xAxis = { categories: categories };
+    config.yAxis = { title: { text: opts.yAxisTitle || '' } };
+    config.series = [{ name: unit, data: values }];
+    if (opts.inverted) config.chart.inverted = true;
+    if (opts.stacking) config.plotOptions = { area: { stacking: opts.stacking } };
+    Highcharts.chart(el, config);
+  }
+
+  function seriesChart(el, chartType, opts) {
+    var categories = JSON.parse(el.dataset.categories);
+    var seriesData = JSON.parse(el.dataset.series);
+    var unit = el.dataset.unit || '';
+    var config = baseOpts(el);
+    config.chart = { type: chartType };
+    if (opts.inverted) config.chart.inverted = true;
+    config.xAxis = { categories: categories };
+    config.yAxis = { title: { text: unit } };
+    config.plotOptions = {};
+    config.plotOptions[chartType] = { stacking: opts.stacking || 'normal' };
+    if (opts.legend) config.legend = { enabled: true, itemWidth: 150 };
+    config.series = seriesData;
+    Highcharts.chart(el, config);
+  }
+
+  function mapChart(el, opts) {
+    var data = JSON.parse(el.dataset.values);
+    var unit = el.dataset.unit || 'publication(s)';
+    var config = baseOpts(el);
+    config.mapNavigation = { enabled: !!opts.nav, buttonOptions: { verticalAlign: 'top' } };
+    config.series = [
+      { name: 'Countries', mapData: Highcharts.maps['custom/world-continents'], color: '#E0E0E0', enableMouseTracking: false },
+      { type: 'mapbubble', name: opts.seriesName || 'Study locations', data: data,
+        tooltip: { pointFormat: opts.tooltipFormat || ('{point.name}: {point.z} ' + unit) },
+        maxSize: '12%' }
+    ];
+    if (opts.dataLabels) config.series[1].dataLabels = { enabled: true, format: '{point.name}' };
+    if (opts.clickable) {
+      config.exporting = { enabled: false };
+      config.chart = { backgroundColor: 'rgba(255, 255, 255, 0)' };
+      config.xAxis = { minRange: 1 };
+      config.yAxis = { minRange: 1 };
+      config.plotOptions = { series: { cursor: 'pointer', point: { events: {
+        click: function() { window.location = this.options.url; }
+      } } } };
+    }
+    Highcharts.mapChart(el, config);
+  }
+
+  var chartTypes = {
+    'bar': function(el) { simpleChart(el, 'bar', {}); },
+    'area': function(el) { simpleChart(el, 'area', { yAxisTitle: el.dataset.unit }); },
+    'depth': function(el) { simpleChart(el, 'area', { inverted: true, stacking: 'normal', yAxisTitle: el.dataset.unit }); },
+    'pie': function(el) {
+      var data = JSON.parse(el.dataset.values);
+      var unit = el.dataset.unit || '';
+      Highcharts.chart(el, {
+        colors: ['#058DC7', '#50B432', '#ED561B', '#DDDF00', '#24CBE5', '#64E572', '#FF9655', '#FFF263', '#6AF9C4'],
+        chart: { type: 'pie' }, title: { text: '' }, credits: { enabled: false }, legend: { enabled: false },
+        plotOptions: { pie: { size: 100, dataLabels: { enabled: true, distance: 0, style: { fontWeight: 'bold', color: 'white' } },
+          startAngle: -90, endAngle: 90, center: ['50%', '90%'] } },
+        series: [{ name: unit, data: data }]
+      });
+    },
+    'area-series': function(el) { seriesChart(el, 'area', {}); },
+    'column-series': function(el) { seriesChart(el, 'column', {}); },
+    'depth-series': function(el) { seriesChart(el, 'area', { inverted: true, stacking: 'percent', legend: true }); },
+    'map': function(el) { mapChart(el, {}); },
+    'map-clickable': function(el) { mapChart(el, { nav: true, clickable: true, dataLabels: true, seriesName: 'Locations', tooltipFormat: '{point.name}' }); },
+  };
+
+  // --- WordCloud2 ---
+
+  function initWordcloud(el) {
+    var list = JSON.parse(el.dataset.wordcloud);
+    var associations = JSON.parse(el.dataset.associations);
+
+    var render = function() {
+      WordCloud(el, {
+        list: list,
+        color: 'black',
+        drawOutOfBound: false,
+        shape: 'square',
+        weightFactor: function(size) { return Math.pow(size, 0.67) * 50; },
+        classes: function(word) {
+          for (var key in associations) {
+            if (associations[key][word] != undefined) return 'associated';
+          }
+        },
+        hover: function() {
+          document.body.style.cursor = document.body.style.cursor === 'pointer' ? 'default' : 'pointer';
+        },
+        click: function(item) {
+          for (var key in associations) {
+            if (associations[key][item[0]] != undefined) {
+              window.location.href = '/' + key + '/' + associations[key][item[0]];
+              return;
+            }
+          }
+          window.location.href = '/publications?search=' + item[0];
+        }
+      });
+    };
+
+    render();
+    var observer = new ResizeObserver(render);
+    observer.observe(el);
+    resizeObservers.push(observer);
+    el.dataset.chartInit = 'true';
+  }
+
+  // --- Event listeners ---
+
+  document.addEventListener('turbolinks:load', initAll);
+  document.addEventListener('turbolinks:before-cache', cleanupObservers);
+  document.addEventListener('render_async_load', initAll);
+})();
+```
+
+The changes from the original:
+- Line 5: `var resizeObservers = [];` — tracks all observers
+- Lines 16-19: `cleanupObservers()` — disconnects all tracked observers
+- Lines 139-141: Store observer in variable, push to `resizeObservers` array
+- Line 147: Add `turbolinks:before-cache` listener to clean up before Turbolinks caches the page
+
+- [ ] **Step 2: Verify charts still work locally**
+
+Run: `rails s`
+- Visit the statistics page — verify all charts render
+- Visit a summary page with a word cloud — verify it renders and is clickable
+- Navigate away and back — verify charts re-render without errors
+- Check browser console for errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+jj new
+jj bookmark create ryan/perf-resize-observer-cleanup
+jj describe -m 'Fix ResizeObserver leak: disconnect observers on turbolinks:before-cache'
+```
+
+- [ ] **Step 4: Push and create PR**
+
+```bash
+jj git push --bookmark ryan/perf-resize-observer-cleanup
+gh pr create --base main --title "Fix ResizeObserver leak in charts" --body "$(cat <<'EOF'
+## Summary
+- Track all `ResizeObserver` instances created by word cloud charts
+- Disconnect them on `turbolinks:before-cache` to prevent memory leaks
+- Each Turbolinks navigation was leaking observers that held references to removed DOM elements
+
+## Test plan
+- [ ] Visit statistics page — all charts render correctly
+- [ ] Visit a summary page with word cloud — cloud renders, words are clickable
+- [ ] Navigate between pages with charts several times — no console errors
+- [ ] In Chrome DevTools Performance tab, verify no growing observer count across navigations
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Bookmark Stacking Summary
+
+The three bookmarks stack as:
+
+```
+main
+ └── ryan/perf-memoize-associations  (Task 1)
+      └── ryan/perf-csv-streaming  (Task 2)
+           └── ryan/perf-resize-observer-cleanup  (Task 3)
+```
+
+Each PR targets `main`. Merge in order: Task 1 first, then Task 2, then Task 3. After each merge, the next PR's diff will automatically clean up.

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -49,13 +49,27 @@ class ApplicationHelperTest < ActionView::TestCase
   test "word_association returns hash of model associations" do
     result = word_association
     assert result.is_a?(Hash)
-    # Should contain entries from Platform, Field, Focusgroup, Location
-    assert result.keys.any?
+    assert_includes result.keys, "platforms"
+    assert_includes result.keys, "fields"
+    assert_includes result.keys, "focusgroups"
+    assert_includes result.keys, "locations"
   end
 
   test "species_association returns array of species data" do
     result = species_association
     assert result.is_a?(Array)
+  end
+
+  test "word_association returns same result on second call (cached)" do
+    first = word_association
+    second = word_association
+    assert_equal first, second
+  end
+
+  test "species_association returns same result on second call (cached)" do
+    first = species_association
+    second = species_association
+    assert_equal first, second
   end
 
   # linkify depends on word_association, species_association, and generates


### PR DESCRIPTION
## Summary
- CSV exports now stream row-by-row via `Enumerator` + `self.response_body`
- Association lookup hashes (fields, focusgroups, platforms, locations) still loaded upfront (4 efficient queries)
- Rows generated and sent one at a time via `find_each(batch_size: 100)` — constant memory regardless of export size
- Existing `csv` scope preserved for backward compatibility

## Test plan
- [x] Sign in, go to publications index, click "Download as CSV" — file downloads correctly
- [x] Sign in, go to a species/location/etc summary page, click "Download as CSV" — file downloads correctly
- [x] Verify CSV content matches expected columns and data
- [x] Check server memory during a large export doesn't spike