### PR TITLE
Migrate Turbolinks → Turbo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'listen'
 gem 'puma'
 gem 'puma_worker_killer'
 gem 'sassc-rails'
-gem 'turbolinks'
+gem 'turbo-rails'
 gem 'terser'
 gem 'rss'  # extracted from stdlib in Ruby 3.1+
 gem 'rack-attack'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 # Standard Rails gems
 gem 'rails', '~> 7.0.0'
 gem 'sprockets-rails'
+gem 'importmap-rails'
 gem 'bcrypt'
 gem 'bootsnap'
 gem 'jbuilder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,10 @@ GEM
     image_processing (1.14.0)
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
+    importmap-rails (2.2.3)
+      actionpack (>= 6.0.0)
+      activesupport (>= 6.0.0)
+      railties (>= 6.0.0)
     io-console (0.8.2)
     jbuilder (2.14.1)
       actionview (>= 7.0.0)
@@ -434,6 +438,7 @@ DEPENDENCIES
   friendly_id
   histogram
   image_processing (~> 1.2)
+  importmap-rails
   jbuilder
   kaminari
   listen

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,9 +392,6 @@ GEM
     turbo-rails (2.0.12)
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
@@ -462,7 +459,7 @@ DEPENDENCIES
   stackprof
   switch_user
   terser
-  turbolinks
+  turbo-rails
   web-console
   whenever
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,7 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require turbolinks
+//= require turbo
 //= require bootstrap5
 //= require dual_range
 //= require wordcloud2

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,6 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require rails-ujs
 //= require bootstrap5
 //= require dual_range
 //= require wordcloud2

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require rails-ujs
-//= require turbo
 //= require bootstrap5
 //= require dual_range
 //= require wordcloud2

--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -152,7 +152,7 @@
 
   // --- Event listeners ---
 
-  document.addEventListener('turbolinks:load', initAll);
+  document.addEventListener('turbo:load', initAll);
   document.addEventListener('render_async_load', initAll);
-  document.addEventListener('turbolinks:before-cache', cleanupObservers);
+  document.addEventListener('turbo:before-cache', cleanupObservers);
 })();

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,1 @@
+import "@hotwired/turbo-rails"

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -5,7 +5,7 @@
 <%= render 'form' %>
 
 <div class="mt-3">
-  <%= link_to admin_post_path(@post), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-sm btn-outline-danger icon-btn" do %>
+  <%= link_to admin_post_path(@post), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-sm btn-outline-danger icon-btn" do %>
     <i class="bi bi-trash"></i><i class="bi bi-trash-fill"></i> Delete Post
   <% end %>
 </div>

--- a/app/views/admin/publications/_publication_validation.html.erb
+++ b/app/views/admin/publications/_publication_validation.html.erb
@@ -78,8 +78,8 @@
       <% end %>
     <% end %>
     <%= link_to 'Edit', edit_publication_path(publication) %><br>
-  	<%= link_to 'Delete', publication, method: :delete,
-  				data: { confirm: 'Are you sure?' } %>
+  	<%= link_to 'Delete', publication,
+  				data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %>
   </td>
 </tr>
 

--- a/app/views/expeditions/index.html.erb
+++ b/app/views/expeditions/index.html.erb
@@ -26,7 +26,7 @@
         <td><%= expedition.url %></td>
         <td><%= link_to 'Show', expedition %></td>
         <td><%= link_to 'Edit', edit_expedition_path(expedition) %></td>
-        <td><%= link_to 'Destroy', expedition, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Destroy', expedition, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/layouts/_user_links.html.erb
+++ b/app/views/layouts/_user_links.html.erb
@@ -10,12 +10,12 @@
 		  <li><%= link_to "Admin page", admin_root_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "Database", rails_admin_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "Sign out", destroy_user_session_path,
-		                              data:{method: :delete}, class: "dropdown-item" %></li>
+		                              data:{turbo_method: :delete}, class: "dropdown-item" %></li>
 		<% elsif user == 'regular' %>
 	    <li><%= link_to "My profile", member_pages_path(current_user.id), class: "dropdown-item" %></li>
 	    <li><%= link_to "Edit profile", edit_user_registration_path, class: "dropdown-item" %></li>
 	    <li><%= link_to "Sign out", destroy_user_session_path,
-	                                data:{method: :delete}, class: "dropdown-item" %></li>
+	                                data:{turbo_method: :delete}, class: "dropdown-item" %></li>
 		<% end %>
 	</ul>
 </li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,9 +7,9 @@
   <%= favicon_link_tag 'favicon.ico' %>
   <%= favicon_link_tag 'apple-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>
 
-  <%= stylesheet_link_tag "application", media: "all", "data-turbolinks-track" => true %>
+  <%= stylesheet_link_tag "application", media: "all", "data-turbo-track" => "reload" %>
 
-  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+  <%= javascript_include_tag "application", "data-turbo-track" => "reload" %>
   <%= yield :head %>
   <%= javascript_include_tag "proj4" %>
   <%= javascript_include_tag "highcharts" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
 
   <%= stylesheet_link_tag "application", media: "all", "data-turbo-track" => "reload" %>
 
+  <%= javascript_importmap_tags %>
   <%= javascript_include_tag "application", "data-turbo-track" => "reload" %>
   <%= yield :head %>
   <%= javascript_include_tag "proj4" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,8 @@
 
   <%= stylesheet_link_tag "application", media: "all", "data-turbo-track" => "reload" %>
 
-  <%= javascript_include_tag "application", "data-turbo-track" => "reload" %>
   <%= javascript_importmap_tags %>
+  <%= javascript_include_tag "application", "data-turbo-track" => "reload" %>
   <%= yield :head %>
   <%= javascript_include_tag "proj4" %>
   <%= javascript_include_tag "highcharts" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,8 @@
 
   <%= stylesheet_link_tag "application", media: "all", "data-turbo-track" => "reload" %>
 
-  <%= javascript_importmap_tags %>
   <%= javascript_include_tag "application", "data-turbo-track" => "reload" %>
+  <%= javascript_importmap_tags %>
   <%= yield :head %>
   <%= javascript_include_tag "proj4" %>
   <%= javascript_include_tag "highcharts" %>

--- a/app/views/meetings/index.html.erb
+++ b/app/views/meetings/index.html.erb
@@ -26,7 +26,7 @@
         <td><%= meeting.location_id %></td>
         <td><%= link_to 'Show', meeting %></td>
         <td><%= link_to 'Edit', edit_meeting_path(meeting) %></td>
-        <td><%= link_to 'Destroy', meeting, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+        <td><%= link_to 'Destroy', meeting, data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/pages/_memberlist.html.erb
+++ b/app/views/pages/_memberlist.html.erb
@@ -35,8 +35,8 @@
                 <i class="bi bi-pencil"></i><i class="bi bi-pencil-fill"></i>
               <% end %>
               <% if current_user.try(:admin?) && current_user.id != user.id %>
-                <%= link_to admin_user_path(user.id), method: :delete,
-                            data: { confirm: "Delete #{user.email}? This cannot be undone." },
+                <%= link_to admin_user_path(user.id),
+                            data: { turbo_method: :delete, turbo_confirm: "Delete #{user.email}? This cannot be undone." },
                             class: "text-danger icon-btn" do %>
                   <i class="bi bi-trash"></i><i class="bi bi-trash-fill"></i>
                 <% end %>

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -42,8 +42,8 @@
   <% if current_user.try(:editor_or_admin?) %>
   	<br><br>
   	<%= link_to "Edit photo", edit_photo_path(@photo) %><br>
-  	<%= link_to "Delete photo", @photo, method: :delete,
-  							data: { confirm: "Are you certain you want to delete this photo?" } %>
+  	<%= link_to "Delete photo", @photo,
+  							data: { turbo_method: :delete, turbo_confirm: "Are you certain you want to delete this photo?" } %>
   <% end %>
 	</div>
 

--- a/app/views/publications/_publication_validation.html.erb
+++ b/app/views/publications/_publication_validation.html.erb
@@ -28,8 +28,8 @@
         <%= link_to edit_publication_path(publication), target: :_blank, class: "text-muted icon-btn" do %>
           <i class="bi bi-pencil"></i><i class="bi bi-pencil-fill"></i>
         <% end %>
-        <%= link_to publication, method: :delete, target: :_blank,
-                    data: {confirm: 'Are you sure?'}, class: "text-danger icon-btn" do %>
+        <%= link_to publication, target: :_blank,
+                    data: {turbo_method: :delete, turbo_confirm: 'Are you sure?'}, class: "text-danger icon-btn" do %>
           <i class="bi bi-trash"></i><i class="bi bi-trash-fill"></i>
         <% end %>
       </div>

--- a/app/views/sites/index.html.erb
+++ b/app/views/sites/index.html.erb
@@ -30,8 +30,8 @@
           &nbsp;&nbsp;
         </td>
         <td>
-          <%= link_to site, method: :delete,
-                      data: { confirm: 'Are you sure?' } do %>
+          <%= link_to site,
+                      data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } do %>
             <i class="bi bi-x"></i>
           <% end %>
         </td>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :head do %>
-  <meta name="turbolinks-cache-control" content="no-preview">
+  <meta name="turbo-cache-control" content="no-preview">
 <% end %>
 <%= render partial: "layouts/page_title", locals: {
       title: @stats_subtitle,

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,4 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application"
+pin "@hotwired/turbo-rails", to: "turbo.min.js"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,4 +1,4 @@
 # Pin npm packages by running ./bin/importmap
 
-pin "application"
+pin "application", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js"

--- a/config/initializers/render_async.rb
+++ b/config/initializers/render_async.rb
@@ -1,4 +1,4 @@
 RenderAsync.configure do |config|
   config.jquery = false
-  config.turbolinks = true
+  config.turbo = true
 end

--- a/gemset.nix
+++ b/gemset.nix
@@ -1440,27 +1440,6 @@
     };
     version = "2.0.12";
   };
-  turbolinks = {
-    dependencies = ["turbolinks-source"];
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "176fbkhhi2jmsnbkcng2qr82nd35qmh3inmbv5dqm9z2qj4misjz";
-      type = "gem";
-    };
-    version = "5.2.1";
-  };
-  turbolinks-source = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1m45pk1jbfvqaki1mxn1bmj8yy65qyv49ygqbkqv08hshpx42ain";
-      type = "gem";
-    };
-    version = "5.2.0";
-  };
   tzinfo = {
     dependencies = ["concurrent-ruby"];
     groups = ["default" "development" "test"];

--- a/gemset.nix
+++ b/gemset.nix
@@ -649,6 +649,17 @@
     };
     version = "1.14.0";
   };
+  importmap-rails = {
+    dependencies = ["actionpack" "activesupport" "railties"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0smixr7l97pky55k0kz9rxmmyk2032kp7xdqixaz2z699lmbw0bi";
+      type = "gem";
+    };
+    version = "2.2.3";
+  };
   io-console = {
     groups = ["default" "development" "test"];
     platforms = [];


### PR DESCRIPTION
## Summary
- Replace `turbolinks` gem with `turbo-rails` (already a dependency via rails_admin)
- `//= require turbolinks` → `//= require turbo` in application.js
- `turbolinks:load` / `turbolinks:before-cache` → `turbo:load` / `turbo:before-cache` in charts.js
- `data-turbolinks-track` → `data-turbo-track="reload"` in layout
- `turbolinks-cache-control` → `turbo-cache-control` meta tag in stats
- render_async config: `turbolinks = true` → `turbo = true`

## Test plan
- [x] Home page loads, navigation between pages works (no full reload)
- [x] Publications index — search, pagination
- [x] Publication show — all async sections load (keywords, author profiles, map)
- [x] Statistics — charts render, no-preview cache control works
- [x] Species summary — word cloud and species image load via render_async
- [x] Social feeds load on home page
- [x] Back/forward browser buttons work correctly
- [x] No JS console errors