### PR TITLE
Photo show polish, paginate members list

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -34,7 +34,7 @@ class PagesController < ApplicationController
   end
 
   def members
-    @users = User.all.order(last_name: :asc).includes(:publications, :organisation)
+    @users = User.all.order(last_name: :asc).includes(:publications, :organisation).page(params[:page]).per(50)
     @publications = Publication.all
     @latest_members = User.order(updated_at: :desc).includes(:publications).limit(15)
     @featured_member = User.joins(:publications)
@@ -47,7 +47,7 @@ class PagesController < ApplicationController
                            .order(Arel.sql("RANDOM()"))
                            .first
     @people_map_data = Rails.cache.fetch(["people_map", User.maximum(:updated_at).to_i]) do
-      helpers.count_geographic_occurrences_of_users(@users)
+      helpers.count_geographic_occurrences_of_users(User.all.includes(:organisation))
     end
     @author_growth = Rails.cache.fetch(["author_growth", Publication.maximum(:updated_at).to_i]) do
       helpers.count_first_authors_over_time(@publications, Time.new.year - 1)

--- a/app/views/pages/members.html.erb
+++ b/app/views/pages/members.html.erb
@@ -4,18 +4,26 @@
 
 <div class="row">
   <div class="col-sm-8">
+    <%= paginate @users %>
+    <div class="mb-3" style="margin-top: -0.5rem;">
+      <small class="text-muted">Displaying members <b><%= @users.offset_value + 1 %>&ndash;<%= @users.offset_value + @users.length %></b> of <b><%= @users.total_count %></b></small>
+    </div>
     <div class="card">
       <div class="card-header">
         <small class="text-muted">
-          <%= @users.count %> people from the publications and member list.
+          <%= @users.total_count %> people from the publications and member list.
         </small>
       </div>
       <div class="card-body p-0">
-        <% cache ["members_list", User.maximum(:updated_at).to_i, Publication.maximum(:updated_at).to_i] do %>
+        <% cache ["members_list", params[:page], User.maximum(:updated_at).to_i, Publication.maximum(:updated_at).to_i] do %>
           <%= render partial: 'memberlist', locals: { users: @users } %>
         <% end %>
       </div>
     </div>
+    <div class="mt-2 mb-2">
+      <small class="text-muted">Displaying members <b><%= @users.offset_value + 1 %>&ndash;<%= @users.offset_value + @users.length %></b> of <b><%= @users.total_count %></b></small>
+    </div>
+    <%= paginate @users %>
   </div>
 
   <div class="col-sm-4">

--- a/app/views/photos/_photo_metadata.html.erb
+++ b/app/views/photos/_photo_metadata.html.erb
@@ -1,73 +1,86 @@
-<strong>Image category tags</strong><br>
-<% if @photo.contains_species %>
-	<span class="badge bg-secondary">Contains species</span>&nbsp;
-<% end %>
-<% if @photo.underwater %>
-	<span class="badge bg-secondary">Underwater photo</span>&nbsp;
-<% else %>
-	<span class="badge bg-secondary">Surface photo</span>&nbsp;
-<% end %><br>
-<% if @photo.platforms.count > 0 %>
+<div class="mb-3">
+  <strong>Tags</strong><br>
+  <% if @photo.contains_species %>
+    <span class="badge border border-secondary text-secondary">Contains species</span>
+  <% end %>
+  <% if @photo.underwater %>
+    <span class="badge border border-secondary text-secondary">Underwater</span>
+  <% else %>
+    <span class="badge border border-secondary text-secondary">Surface</span>
+  <% end %>
   <% @photo.platforms.each do |platform| %>
-  	<span class="badge bg-secondary"><%= platform.description %></span>&nbsp;
-  <% end %><br>
-<% end %>
-
+    <span class="badge border border-secondary text-secondary"><%= platform.description %></span>
+  <% end %>
+</div>
 
 <% if @photo.underwater? %>
-	<br><strong>Image depth</strong><br>
-	<%= @photo.depth %> m<br>
+  <div class="mb-3">
+    <strong>Depth</strong><br>
+    <%= @photo.depth %> m
+  </div>
 <% end %>
 
 <% if @photo.location %>
-  <br><strong>Image location</strong><br>
-  <%= link_to @photo.location.description, location_path(@photo.location) %><br>
+  <div class="mb-3">
+    <strong>Location</strong><br>
+    <%= link_to @photo.location.description, location_path(@photo.location) %>
+  </div>
 <% end %>
 
 <% if @photo.site %>
-  <br><strong>Image site</strong><br>
-  <%= link_to @photo.site.site_name, site_path(@photo.site) %><br>
+  <div class="mb-3">
+    <strong>Site</strong><br>
+    <%= link_to @photo.site.site_name, site_path(@photo.site) %>
+  </div>
 <% end %>
 
 <% if @photo.expedition %>
-  <br><strong>Coupled expedition</strong><br>
-  <%= link_to @photo.expedition.title, expedition_path(@photo.expedition) %>
-  <br>
+  <div class="mb-3">
+    <strong>Expedition</strong><br>
+    <%= link_to @photo.expedition.title, expedition_path(@photo.expedition) %>
+  </div>
 <% end %>
 
 <% if @photo.meeting %>
-  <br><strong>Coupled meeting</strong><br>
-  <%= link_to @photo.meeting.title, meeting_path(@photo.meeting) %>
-  <br>
+  <div class="mb-3">
+    <strong>Meeting</strong><br>
+    <%= link_to @photo.meeting.title, meeting_path(@photo.meeting) %>
+  </div>
 <% end %>
 
 <% if @photo.post %>
-  <br><strong>Coupled post</strong><br>
-  <%= link_to @photo.post.title,
-              post_pages_path(@photo.post.slug) %>
-  <br>
+  <div class="mb-3">
+    <strong>Post</strong><br>
+    <%= link_to @photo.post.title, post_pages_path(@photo.post.slug) %>
+  </div>
 <% end %>
 
 <% if @photo.publication %>
-  <br><strong>Coupled publication</strong><br>
-  <%= link_to @photo.publication.short_citation_with_title,
-  						publication_path(@photo.publication) %>
-  <br>
+  <div class="mb-3">
+    <strong>Publication</strong><br>
+    <%= link_to @photo.publication.short_citation_with_title, publication_path(@photo.publication) %>
+  </div>
 <% end %>
 
 <% if @photo.organisations.count > 0 %>
-  <br><strong>Organisations (tagged)</strong><br>
-  <% @photo.organisations.each do |organisation| %>
-  	<%= organisation.name %><br>
-  <% end %>
+  <div class="mb-3">
+    <strong>Organisations</strong><br>
+    <% @photo.organisations.each do |organisation| %>
+      <%= organisation.name %><br>
+    <% end %>
+  </div>
 <% end %>
 
 <% if @photo.users.count > 0 %>
-  <br><strong>Researchers (tagged)</strong><br>
-  <% @photo.users.each do |user| %>
-  	<%= link_to user.full_name, member_pages_path(user) %><br>
-  <% end %>
+  <div class="mb-3">
+    <strong>Researchers</strong><br>
+    <% @photo.users.each do |user| %>
+      <%= link_to user.full_name, member_pages_path(user) %><br>
+    <% end %>
+  </div>
 <% end %>
 
-<br><strong>Date uploaded</strong><br>
-<%= l @photo.image.created_at.to_date, format: :long %><br>
+<div class="mb-0">
+  <strong>Uploaded</strong><br>
+  <small class="text-muted"><%= l @photo.image.created_at.to_date, format: :long %></small>
+</div>

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -1,70 +1,60 @@
 <%= render partial: "layouts/page_title",
        locals: {title: "Images",
-       			subtitle: @photo.description_truncated,
                 breadcrumbs: [["Images", photos_path], [@photo.description_truncated, nil]] } %>
 
 <div class="row">
   <div class="col-sm-8">
 
-  <div class="row">
-	  <div class="col-sm-1" align="left">
-	  	<h4>
-		  	<%= link_to photo_path(@photo.previous), title: "" do %>
-		  		<i class="bi bi-chevron-left"></i>
-				<% end %>
-			</h4>
-		</div>
-		<div class="col-sm-10">
-	    <h4>
-	      <%= @photo.description %>
-	    </h4>
-		</div>
-		<div class="col-sm-1" align="right">
-			<h4>
-		  	<%= link_to photo_path(@photo.next), title:  "" do %>
-		  		<i class="bi bi-chevron-right"></i>
-				<% end %>
-			</h4>
-	  </div>
-  </div>
+    <div class="card">
+      <div class="card-body p-0 position-relative" style="background-color: #f0f1f3;">
+        <%= image_tag @photo.image.variant(resize: "1024x768>"), style: "width: 100%; display: block;" %>
+        <div class="position-absolute top-50 start-0 translate-middle-y ps-2">
+          <%= link_to photo_path(@photo.previous), class: "text-white", style: "font-size: 1.5rem; text-shadow: 0 0 6px rgba(0,0,0,0.5);" do %>
+            <i class="bi bi-chevron-left"></i>
+          <% end %>
+        </div>
+        <div class="position-absolute top-50 end-0 translate-middle-y pe-2">
+          <%= link_to photo_path(@photo.next), class: "text-white", style: "font-size: 1.5rem; text-shadow: 0 0 6px rgba(0,0,0,0.5);" do %>
+            <i class="bi bi-chevron-right"></i>
+          <% end %>
+        </div>
+      </div>
+      <div class="card-footer d-flex justify-content-between align-items-center">
+        <div>
+          <strong><%= @photo.description %></strong><br>
+          <small class="text-muted">
+            &copy; <%= @photo.credit %>
+            <% if @photo.creative_commons %>
+              &middot; <a href="https://creativecommons.org/licenses/by-nc/4.0/" class="text-muted">CC BY-NC 4.0</a>
+            <% end %>
+          </small>
+        </div>
+        <% if current_user.try(:editor_or_admin?) %>
+          <div class="d-flex gap-2">
+            <%= link_to edit_photo_path(@photo), class: "text-muted icon-btn" do %><i class="bi bi-pencil"></i><i class="bi bi-pencil-fill"></i><% end %>
+            <%= link_to @photo, data: { turbo_method: :delete, turbo_confirm: "Are you certain you want to delete this photo?" }, class: "text-danger icon-btn" do %><i class="bi bi-trash"></i><i class="bi bi-trash-fill"></i><% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
 
-	<div style="background-color: #f0f1f3;">
-    <%= image_tag @photo.image.variant(resize: "1024x768>"), style: "width: 100%;" %>
   </div>
-	(C) <%= @photo.credit %>
-  <% if @photo.creative_commons %>
-    - Creative Commons License
-    <a href="https://creativecommons.org/licenses/by-nc/4.0/">
-      (CC BY-NC 4.0)
-    </a>
-  <% end %>
-
-  <% if current_user.try(:editor_or_admin?) %>
-  	<br><br>
-  	<%= link_to "Edit photo", edit_photo_path(@photo) %><br>
-  	<%= link_to "Delete photo", @photo, method: :delete,
-  							data: { confirm: "Are you certain you want to delete this photo?" } %>
-  <% end %>
-	</div>
 
   <div class="col-sm-4">
-		<% if @photo.has_place? %>
-    <div class="card">
-      <div class="card-header"><strong>Image Location/Site</strong></div>
-      <div class="card-body" align="center" style="min-height: 150px;">
-        <%= render_async world_map_path(key: "photos_show", model: Photo, ids: @photo.id, height: 150, z: 1) %>
+    <% if @photo.has_place? %>
+      <div class="card">
+        <div class="card-header"><strong>Image Location</strong></div>
+        <div class="card-body p-1" style="min-height: 150px;">
+          <%= render_async world_map_path(key: "photos_show", model: Photo, ids: @photo.id, height: 150, z: 1) %>
+        </div>
       </div>
-    </div>
-		<% end %>
+    <% end %>
 
     <div class="card">
-      <div class="card-header">
-        <strong>Image metadata </strong>
-	  	</div>
+      <div class="card-header"><strong>Image Metadata</strong></div>
       <div class="card-body">
-      	<%= render partial: 'photo_metadata' %>
+        <%= render partial: 'photo_metadata' %>
       </div>
     </div>
-
   </div>
 </div>

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "layouts/page_title",
-       locals: {title: "Images",
+       locals: {title: "",
+                page_title: "Images",
                 breadcrumbs: [["Images", photos_path], [@photo.description_truncated, nil]] } %>
 
 <div class="row">

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -7,34 +7,38 @@
   <div class="col-sm-8">
 
     <div class="card">
-      <div class="card-body p-0 position-relative" style="background-color: #f0f1f3;">
-        <%= image_tag @photo.image.variant(resize: "1024x768>"), style: "width: 100%; display: block;" %>
-        <div class="position-absolute top-50 start-0 translate-middle-y ps-2">
-          <%= link_to photo_path(@photo.previous), class: "text-white", style: "font-size: 1.5rem; text-shadow: 0 0 6px rgba(0,0,0,0.5);" do %>
-            <i class="bi bi-chevron-left"></i>
-          <% end %>
-        </div>
-        <div class="position-absolute top-50 end-0 translate-middle-y pe-2">
-          <%= link_to photo_path(@photo.next), class: "text-white", style: "font-size: 1.5rem; text-shadow: 0 0 6px rgba(0,0,0,0.5);" do %>
-            <i class="bi bi-chevron-right"></i>
-          <% end %>
-        </div>
-      </div>
-      <div class="card-footer d-flex justify-content-between align-items-center">
-        <div>
-          <strong><%= @photo.description %></strong><br>
-          <small class="text-muted">
-            &copy; <%= @photo.credit %>
-            <% if @photo.creative_commons %>
-              &middot; <a href="https://creativecommons.org/licenses/by-nc/4.0/" class="text-muted">CC BY-NC 4.0</a>
-            <% end %>
-          </small>
-        </div>
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <%= link_to photo_path(@photo.previous), class: "text-muted text-decoration-none" do %>
+          <i class="bi bi-chevron-left"></i> <small>Previous</small>
+        <% end %>
         <% if current_user.try(:editor_or_admin?) %>
           <div class="d-flex gap-2">
             <%= link_to edit_photo_path(@photo), class: "text-muted icon-btn" do %><i class="bi bi-pencil"></i><i class="bi bi-pencil-fill"></i><% end %>
             <%= link_to @photo, data: { turbo_method: :delete, turbo_confirm: "Are you certain you want to delete this photo?" }, class: "text-danger icon-btn" do %><i class="bi bi-trash"></i><i class="bi bi-trash-fill"></i><% end %>
           </div>
+        <% end %>
+        <%= link_to photo_path(@photo.next), class: "text-muted text-decoration-none" do %>
+          <small>Next</small> <i class="bi bi-chevron-right"></i>
+        <% end %>
+      </div>
+      <div class="card-body p-0" style="background-color: #f0f1f3;">
+        <%= image_tag @photo.image.variant(resize: "1024x768>"), style: "width: 100%; display: block;" %>
+      </div>
+      <div class="card-footer">
+        <strong><%= @photo.description %></strong><br>
+        <small class="text-muted">
+          &copy; <%= @photo.credit %>
+          <% if @photo.creative_commons %>
+            &middot; <a href="https://creativecommons.org/licenses/by-nc/4.0/" class="text-muted">CC BY-NC 4.0</a>
+          <% end %>
+        </small>
+      </div>
+      <div class="card-footer d-flex justify-content-between align-items-center">
+        <%= link_to photo_path(@photo.previous), class: "text-muted text-decoration-none" do %>
+          <i class="bi bi-chevron-left"></i> <small>Previous</small>
+        <% end %>
+        <%= link_to photo_path(@photo.next), class: "text-muted text-decoration-none" do %>
+          <small>Next</small> <i class="bi bi-chevron-right"></i>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **Photo show page**: Card layout with Previous/Next nav in header and footer, description and credit in footer, outline badges for metadata tags, icon-btn edit/delete for editors
- **Members list**: Paginated (50 per page) with page info, card header with total count
- **Photo metadata**: Clean spacing with `mb-3` divs, outline badges for tags

## Test plan
- [x] Photo show — Previous/Next nav works in header and footer
- [x] Photo show — description, credit, CC license in footer
- [x] Photo show — edit/delete icons visible for editors
- [x] Members page — pagination works, 50 per page
- [x] Members page — total count in card header
- [x] Members page — map still shows all members (not just current page)