### PR TITLE
Replace render_async with Turbo Frames

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'figaro'
 gem 'histogram'
 gem 'paper_trail'
 gem 'rails_admin'
-gem 'render_async'
 gem 'switch_user'
 
 # ActiveStorage, wont be required after we migrate to Rails 6+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,6 @@ GEM
     drb (2.2.3)
     erb (6.0.2)
     erubi (1.13.1)
-    ffi (1.17.4)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -382,7 +381,6 @@ GEM
     redcarpet (3.6.1)
     reline (0.6.3)
       io-console (~> 0.5)
-    render_async (2.1.11)
     request_store (1.7.0)
       rack (>= 1.4)
     responders (3.2.0)
@@ -486,7 +484,6 @@ DEPENDENCIES
   rails-erd
   rails_admin
   redcarpet
-  render_async
   rss
   spring
   sqlite3 (~> 2.0)

--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -153,6 +153,7 @@
   // --- Event listeners ---
 
   document.addEventListener('turbo:load', initAll);
+  document.addEventListener('turbo:frame-load', initAll);
   document.addEventListener('render_async_load', initAll);
   document.addEventListener('turbo:before-cache', cleanupObservers);
 })();

--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -1,5 +1,5 @@
 // Auto-initialize Highcharts, Highcharts Maps, and WordCloud2 from data attributes.
-// Works with both direct rendering and render_async injection (no inline scripts needed).
+// Works with both direct rendering and Turbo Frames lazy loading (no inline scripts needed).
 
 (function() {
   var resizeObservers = [];
@@ -154,6 +154,5 @@
 
   document.addEventListener('turbo:load', initAll);
   document.addEventListener('turbo:frame-load', initAll);
-  document.addEventListener('render_async_load', initAll);
-  document.addEventListener('turbo:before-cache', cleanupObservers);
+document.addEventListener('turbo:before-cache', cleanupObservers);
 })();

--- a/app/assets/javascripts/feed_tabs.js
+++ b/app/assets/javascripts/feed_tabs.js
@@ -20,8 +20,8 @@ function switchFeed(platform) {
   document.getElementById('feed-platform').textContent = names[platform];
 }
 
-// After Bluesky feed loads via render_async, hide the tab if empty
-document.addEventListener('render_async_load', function() {
+// After Bluesky feed loads, hide the tab if empty
+function checkBlueskyFeed() {
   var blueskyTab = document.getElementById('tab-bluesky');
   if (!blueskyTab) return;
 
@@ -34,4 +34,6 @@ document.addEventListener('render_async_load', function() {
 
   var hasContent = blueskyFeed.querySelector('.mastodon-status');
   blueskyTab.style.display = hasContent ? '' : 'none';
-});
+}
+document.addEventListener('render_async_load', checkBlueskyFeed);
+document.addEventListener('turbo:frame-load', checkBlueskyFeed);

--- a/app/assets/javascripts/feed_tabs.js
+++ b/app/assets/javascripts/feed_tabs.js
@@ -35,5 +35,4 @@ function checkBlueskyFeed() {
   var hasContent = blueskyFeed.querySelector('.mastodon-status');
   blueskyTab.style.display = hasContent ? '' : 'none';
 }
-document.addEventListener('render_async_load', checkBlueskyFeed);
 document.addEventListener('turbo:frame-load', checkBlueskyFeed);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -102,4 +102,10 @@ class ApplicationController < ActionController::Base
   end
 
   helper_method :require_admin_or_editor!
+
+  # Wrap content in a turbo-frame tag for Turbo Frames lazy loading.
+  def render_in_turbo_frame(id)
+    content = yield
+    render html: helpers.turbo_frame_tag(id) { content.html_safe }.html_safe, layout: false
+  end
 end

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -8,7 +8,7 @@ class MapsController < ApplicationController
                        backgroundcolor: params[:backgroundcolor],
                        height: params[:height] }
     end
-    render html: cached.html_safe
+    render_in_turbo_frame("world-map-#{params[:key]}") { cached }
   end
 
   private

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -14,7 +14,7 @@ class PagesController < ApplicationController
       u = User.where(mastodon_handle: s.map { |status| ["@#{status.username}", status.username] }.flatten)
       [s, u]
     end
-    render partial: 'mastodon_feed', locals: { statuses: statuses, users: users }
+    render_in_turbo_frame("mastodon-feed") { render_to_string partial: 'mastodon_feed', locals: { statuses: statuses, users: users } }
   end
 
   def bluesky_feed
@@ -23,7 +23,7 @@ class PagesController < ApplicationController
       u = User.where(bluesky_handle: s.map(&:username))
       [s, u]
     end
-    render partial: 'bluesky_feed', locals: { statuses: statuses, users: users }
+    render_in_turbo_frame("bluesky-feed") { render_to_string partial: 'bluesky_feed', locals: { statuses: statuses, users: users } }
   end
 
   def inside
@@ -116,13 +116,13 @@ class PagesController < ApplicationController
       word_cloud = publications.word_cloud(40)
       word_cloud.present? ? render_to_string(partial: 'shared/wordcloud', object: word_cloud, locals: { title: 'publication_contents' }) : ""
     end
-    render html: cached.html_safe
+    render_in_turbo_frame("member-keywords-#{params[:id]}") { cached }
   end
 
   def member_research_summary
     cached = Rails.cache.fetch(["member_research_summary", params[:id], Publication.maximum(:updated_at).to_i]) do
       render_to_string partial: 'research_summary', locals: { user: User.find(params[:id]) }
     end
-    render html: cached.html_safe
+    render_in_turbo_frame("member-research-summary-#{params[:id]}") { cached }
   end
 end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -166,18 +166,16 @@ class PublicationsController < ApplicationController
   end
 
   def publication_authors
-    render partial: "authors", object: @publication.users
+    render_in_turbo_frame("publication-authors-#{@publication.id}") { render_to_string partial: "authors", object: @publication.users }
   end
 
   def publication_keywords
     publications = Publication.select(:contents).where(id: params[:id])
     word_cloud = publications.word_cloud(40)
 
-    if word_cloud.present?
-      render partial: 'shared/wordcloud',
-             object: word_cloud,
-             locals: { title: 'publication_contents' }
-    end
+    render_in_turbo_frame("publication-keywords-#{params[:id]}") {
+      word_cloud.present? ? render_to_string(partial: 'shared/wordcloud', object: word_cloud, locals: { title: 'publication_contents' }) : ""
+    }
   end
 
   private

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -52,15 +52,13 @@ class SitesController < ApplicationController
     publications = Publication.select(:contents).joins(:sites).where("sites.id == ?", params[:id])
     word_cloud = publications.word_cloud(40)
 
-    if word_cloud.present?
-      render partial: 'shared/wordcloud',
-             object: word_cloud,
-             locals: { title: 'location_publication_contents' }
-    end
+    render_in_turbo_frame("site-keywords-#{params[:id]}") {
+      word_cloud.present? ? render_to_string(partial: 'shared/wordcloud', object: word_cloud, locals: { title: 'location_publication_contents' }) : ""
+    }
   end
 
   def site_research_details
-    render partial: 'research_details', object: @site.publications
+    render_in_turbo_frame("site-research-details-#{params[:id]}") { render_to_string partial: 'research_details', object: @site.publications }
   end
 
   private

--- a/app/controllers/species_controller.rb
+++ b/app/controllers/species_controller.rb
@@ -12,7 +12,7 @@ class SpeciesController < ApplicationController
   end
 
   def species_image
-    render partial: 'species_image', locals: { object: @species }
+    render_in_turbo_frame("species-image-#{params[:id]}") { render_to_string partial: 'species_image', locals: { object: @species } }
   end
 
   private

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -47,19 +47,19 @@ class StatsController < ApplicationController
   end
 
   def growing_depth_range
-    render partial: "growing_depth_range"
+    render_in_turbo_frame("stats-growing_depth_range") { render_to_string partial: "growing_depth_range" }
   end
 
   def growing_publications_over_time
-    render partial: "growing_publications_over_time"
+    render_in_turbo_frame("stats-growing_publications_over_time") { render_to_string partial: "growing_publications_over_time" }
   end
 
   def growing_locations_over_time
-    render partial: "growing_locations_over_time"
+    render_in_turbo_frame("stats-growing_locations_over_time") { render_to_string partial: "growing_locations_over_time" }
   end
 
   def growing_authors_over_time
-    render partial: "growing_authors_over_time"
+    render_in_turbo_frame("stats-growing_authors_over_time") { render_to_string partial: "growing_authors_over_time" }
   end
 
   def summarized_fields
@@ -71,7 +71,7 @@ class StatsController < ApplicationController
       .group('fields.id')
       .order(Arel.sql('count(fields.id) DESC'))
 
-    render partial: "summarized_fields"
+    render_in_turbo_frame("stats-summarized_fields") { render_to_string partial: "summarized_fields" }
   end
 
   def summarized_journals
@@ -83,7 +83,7 @@ class StatsController < ApplicationController
       .group('journals.id')
       .order(Arel.sql('count(journals.id) DESC'))
 
-    render partial: "summarized_journals"
+    render_in_turbo_frame("stats-summarized_journals") { render_to_string partial: "summarized_journals" }
   end
 
   def summarized_focusgroups
@@ -95,7 +95,7 @@ class StatsController < ApplicationController
       .group('focusgroups.id')
       .order(Arel.sql('count(focusgroups.id) DESC'))
 
-    render partial: "summarized_focusgroups"
+    render_in_turbo_frame("stats-summarized_focusgroups") { render_to_string partial: "summarized_focusgroups" }
   end
 
   def summarized_platforms
@@ -107,17 +107,17 @@ class StatsController < ApplicationController
       .group('platforms.id')
       .order(Arel.sql('count(platforms.id) DESC'))
 
-    render partial: "summarized_platforms"
+    render_in_turbo_frame("stats-summarized_platforms") { render_to_string partial: "summarized_platforms" }
   end
 
   def world_publications
-    render partial: "world_publications"
+    render_in_turbo_frame("stats-world_publications") { render_to_string partial: "world_publications" }
   end
 
   def world_users
     @users = User.all
 
-    render partial: "world_users"
+    render_in_turbo_frame("stats-world_users") { render_to_string partial: "world_users" }
   end
 
   def world_locations
@@ -129,19 +129,19 @@ class StatsController < ApplicationController
       .group('locations.id')
       .order(Arel.sql('count(locations.id) DESC'))
 
-    render partial: "world_locations"
+    render_in_turbo_frame("stats-world_locations") { render_to_string partial: "world_locations" }
   end
 
   def time_refuge
     @annual_refuge_counts = @publications.relevance('refug').annual_counts
 
-    render partial: "time_refuge"
+    render_in_turbo_frame("stats-time_refuge") { render_to_string partial: "time_refuge" }
   end
 
   def time_mesophotic
     @annual_mesophotic_counts = @publications.relevance('mesophotic').annual_counts
 
-    render partial: "time_mesophotic"
+    render_in_turbo_frame("stats-time_mesophotic") { render_to_string partial: "time_mesophotic" }
   end
 
   private

--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -22,14 +22,14 @@ class SummaryController < ApplicationController
       word_cloud = publications.word_cloud(40)
       word_cloud.present? ? render_to_string(partial: 'shared/wordcloud', object: word_cloud, locals: { title: "#{params[:model]}_publication_contents" }) : ""
     end
-    render html: cached.html_safe
+    render_in_turbo_frame("summary-keywords-#{params[:model]}-#{params[:id]}") { cached }
   end
 
   def summary_researchers
     cached = Rails.cache.fetch(["summary_researchers", params[:model], params[:id], Publication.maximum(:updated_at).to_i]) do
       render_to_string partial: 'author', collection: publications.authors
     end
-    render html: cached.html_safe
+    render_in_turbo_frame("summary-researchers-#{params[:model]}-#{params[:id]}") { cached }
   end
 
   def summary_publications
@@ -41,7 +41,7 @@ class SummaryController < ApplicationController
                "Platforms": platforms
              }
     end
-    render html: cached.html_safe
+    render_in_turbo_frame("summary-publications-#{params[:model]}-#{params[:id]}") { cached }
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,8 +49,7 @@
 
   </div>
 
-  <%= content_for :render_async %>
-  <%= render 'layouts/footer' %>
+<%= render 'layouts/footer' %>
 	<%= debug(params) if Rails.env.development? %>
 </body>
 </html>

--- a/app/views/locations/_dropdown_body.html.erb
+++ b/app/views/locations/_dropdown_body.html.erb
@@ -1,5 +1,5 @@
 <div class="card-body" style="min-height: 293px;">
   <% model = object.sites.count > 0 ? Site : Location %>
   <% places = object.sites.count > 0 ? object.sites : [object] %>
-  <%= render_async world_map_path(key: "#{model}_dropdown_body", model: model, ids: places.map(&:id).join(','), height: 293) %>
+  <%= turbo_frame_tag "world-map-#{model}_dropdown_body", src: world_map_path(key: "#{model}_dropdown_body", model: model, ids: places.map(&:id).join(','), height: 293), loading: :lazy %>
 </div>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -25,7 +25,7 @@
         <% end %>
       </div>
       <div class="col-5" style="min-height: 230px;">
-        <%= render_async world_map_path(key: "locations_form", model: Location, ids: location.id, height: 230) %>
+        <%= turbo_frame_tag "world-map-locations_form", src: world_map_path(key: "locations_form", model: Location, ids: location.id, height: 230), loading: :lazy %>
       </div>
     </div>
   </div>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -17,7 +17,7 @@
   <div class="col-sm-8">
     <div class="card mb-0 h-100">
       <div class="card-body p-0" style="min-height: 380px;">
-        <%= render_async world_map_path(key: "locations_index", model: Location, ids: @locations.map(&:id).join(','), height: 380) %>
+        <%= turbo_frame_tag "world-map-locations_index", src: world_map_path(key: "locations_index", model: Location, ids: @locations.map(&:id).join(','), height: 380), loading: :lazy %>
       </div>
     </div>
   </div>

--- a/app/views/pages/_post_behind.html.erb
+++ b/app/views/pages/_post_behind.html.erb
@@ -51,7 +51,7 @@
     <div class="card">
       <div class="card-header"><strong>Study Location</strong></div>
       <div class="card-body" style="min-height: 150px;">
-        <%= render_async world_map_path(key: "pages_post_behind", model: Location, ids: @publication.locations.map(&:id).join(','), height: 150, z: 1) %>
+        <%= turbo_frame_tag "world-map-pages_post_behind", src: world_map_path(key: "pages_post_behind", model: Location, ids: @publication.locations.map(&:id).join(','), height: 150, z: 1), loading: :lazy %>
       </div>
     </div>
     <div class="card">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,7 +3,7 @@
 <div class="card">
   <div class="card-body background_image d-flex align-items-center justify-content-center p-0">
     <div style="width: 100%; max-width: 700px; height: 300px;">
-      <%= render_async world_map_path(key: "pages_home", model: Location, ids: @locations.map(&:id).join(','), height: 300, backgroundcolor: '#FCFFC5') %>
+      <%= turbo_frame_tag "world-map-pages_home", src: world_map_path(key: "pages_home", model: Location, ids: @locations.map(&:id).join(','), height: 300, backgroundcolor: '#FCFFC5') %>
     </div>
   </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -50,7 +50,7 @@
       </div>
       <div class="card-body">
         <div id="feed-mastodon" style="display: none;">
-          <%= render_async mastodon_feed_pages_path do %>
+          <%= turbo_frame_tag "mastodon-feed", src: mastodon_feed_pages_path do %>
             <div class="text-center text-muted py-4">
               <div class="spinner-border spinner-border-sm me-2" role="status"></div>
               Loading feed...
@@ -58,7 +58,7 @@
           <% end %>
         </div>
         <div id="feed-bluesky">
-          <%= render_async bluesky_feed_pages_path do %>
+          <%= turbo_frame_tag "bluesky-feed", src: bluesky_feed_pages_path do %>
             <div class="text-center text-muted py-4">
               <div class="spinner-border spinner-border-sm me-2" role="status"></div>
               Loading feed...

--- a/app/views/pages/show_member.html.erb
+++ b/app/views/pages/show_member.html.erb
@@ -90,7 +90,7 @@
       <div class="card">
         <div class="card-header"><strong>Research Keywords</strong></div>
         <div class="card-body" style="min-height: 232px;">
-          <%= render_async member_keywords_path(id: @user.id) %>
+          <%= turbo_frame_tag "member-keywords-#{@user.id}", src: member_keywords_path(id: @user.id), loading: :lazy %>
         </div>
       </div>
     <% end %>
@@ -131,7 +131,7 @@
       <div class="card">
         <div class="card-header"><strong>Research Summary</strong></div>
         <div class="card-body">
-          <%= render_async member_research_summary_path(id: @user.id) %>
+          <%= turbo_frame_tag "member-research-summary-#{@user.id}", src: member_research_summary_path(id: @user.id), loading: :lazy %>
         </div>
       </div>
     <% end %>

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -50,7 +50,7 @@
       <div class="card">
         <div class="card-header"><strong>Image Location</strong></div>
         <div class="card-body p-1" style="min-height: 150px;">
-          <%= render_async world_map_path(key: "photos_show", model: Photo, ids: @photo.id, height: 150, z: 1) %>
+          <%= turbo_frame_tag "world-map-photos_show", src: world_map_path(key: "photos_show", model: Photo, ids: @photo.id, height: 150, z: 1), loading: :lazy %>
         </div>
       </div>
     <% end %>

--- a/app/views/publications/index.html.erb
+++ b/app/views/publications/index.html.erb
@@ -73,7 +73,7 @@
     <div class="card">
       <div class="card-header"><strong>Locations</strong></div>
       <div class="card-body" align="center" style="min-height: 150px;">
-        <%= render_async world_map_path(key: "publications_index", model: Location, ids: @locations, height: 150) %>
+        <%= turbo_frame_tag "world-map-publications_index", src: world_map_path(key: "publications_index", model: Location, ids: @locations, height: 150), loading: :lazy %>
       </div>
     </div>
     <% cache ["publications_sidebar_focus", Publication.maximum(:updated_at).to_i] do %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -58,7 +58,7 @@
       <div class="card">
         <div class="card-header"><strong>Research Sites</strong></div>
         <div class="card-body" style="min-height: 300px;">
-          <%= render_async world_map_path(key: "publications_show", model: Site, ids: @publication.sites.map(&:id).join(','), height: 300, z: 1) %>
+          <%= turbo_frame_tag "world-map-publications_show", src: world_map_path(key: "publications_show", model: Site, ids: @publication.sites.map(&:id).join(','), height: 300, z: 1), loading: :lazy %>
         </div>
         <div class="card-footer">
           <table class="table table-sm mb-0">

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -89,7 +89,7 @@
       <div class="card">
         <div class="card-header"><strong>Keywords</strong></div>
         <div class="card-body" style="min-height: 232px;">
-          <%= render_async publication_keywords_path(id: @publication.id) %>
+          <%= turbo_frame_tag "publication-keywords-#{@publication.id}", src: publication_keywords_path(id: @publication.id), loading: :lazy %>
         </div>
       </div>
     <% end %>
@@ -163,7 +163,7 @@
       <div class="card">
         <div class="card-header"><strong>Author Profiles</strong></div>
         <div class="card-body">
-          <%= render_async publication_authors_path(id: @publication.id) %>
+          <%= turbo_frame_tag "publication-authors-#{@publication.id}", src: publication_authors_path(id: @publication.id), loading: :lazy %>
         </div>
       </div>
     <% end %>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -26,7 +26,7 @@
         </div>
       </div>
       <div class="col-5" style="min-height: 230px;">
-        <%= render_async world_map_path(key: "sites_form", model: Site, ids: site.id, height: 230, z: 10) %>
+        <%= turbo_frame_tag "world-map-sites_form", src: world_map_path(key: "sites_form", model: Site, ids: site.id, height: 230, z: 10), loading: :lazy %>
       </div>
     </div>
   </div>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -25,7 +25,7 @@
         <strong>Research keywords</strong>
       </div>
       <div class="card-body" style="min-height: 232px;">
-        <%= render_async site_keywords_path(id: @site.id) %>
+        <%= turbo_frame_tag "site-keywords-#{@site.id}", src: site_keywords_path(id: @site.id), loading: :lazy %>
 			</div>
 		</div>
 
@@ -35,7 +35,7 @@
           <strong>Research details</strong> (top 5 / category)
         </div>
         <div class="card-body">
-          <%= render_async site_research_details_path(id: @site.id) %>
+          <%= turbo_frame_tag "site-research-details-#{@site.id}", src: site_research_details_path(id: @site.id), loading: :lazy %>
         </div>
       </div>
     <% end %>

--- a/app/views/species/_show.html.erb
+++ b/app/views/species/_show.html.erb
@@ -30,7 +30,7 @@
   <div class="col-sm-4">
     <div class="card" style="min-height: 200px; background-color: #f0f1f3;">
       <div class="card-header"><strong>Species Image</strong></div>
-      <%= render_async species_image_path(id: object.id) do %>
+      <%= turbo_frame_tag "species-image-#{object.id}", src: species_image_path(id: object.id) do %>
         <div class="d-flex justify-content-center align-items-center" style="min-height: 150px;">
           <div class="spinner-border text-secondary" role="status">
             <span class="visually-hidden">Loading...</span>

--- a/app/views/stats/_growing.html.erb
+++ b/app/views/stats/_growing.html.erb
@@ -7,10 +7,10 @@
   <div class="card-body">
     <div class="row">
       <div class="col-sm-6" style="min-height: 330px;">
-        <%= render_async growing_depth_range_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-growing_depth_range", src: growing_depth_range_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
       <div class="col-sm-6" style="min-height: 330px;">
-        <%= render_async growing_publications_over_time_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-growing_publications_over_time", src: growing_publications_over_time_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
     </div>
 
@@ -18,10 +18,10 @@
 
     <div class="row">
       <div class="col-sm-6" style="min-height: 230px;">
-        <%= render_async growing_locations_over_time_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-growing_locations_over_time", src: growing_locations_over_time_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
       <div class="col-sm-6" style="min-height: 230px;">
-        <%= render_async growing_authors_over_time_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-growing_authors_over_time", src: growing_authors_over_time_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
     </div>
   </div>

--- a/app/views/stats/_summarized.html.erb
+++ b/app/views/stats/_summarized.html.erb
@@ -9,10 +9,10 @@
   <div class="card-body">
     <div class="row">
       <div class="col-sm-6" style="min-height: 300px;">
-        <%= render_async summarized_fields_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-summarized_fields", src: summarized_fields_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
       <div class="col-sm-6" style="min-height: 300px;">
-        <%= render_async summarized_journals_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-summarized_journals", src: summarized_journals_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
     </div>
 
@@ -20,10 +20,10 @@
 
     <div class="row">
       <div class="col-sm-6" style="min-height: 300px;">
-        <%= render_async summarized_focusgroups_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-summarized_focusgroups", src: summarized_focusgroups_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
       <div class="col-sm-6" style="min-height: 300px;">
-        <%= render_async summarized_platforms_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-summarized_platforms", src: summarized_platforms_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
     </div>
   </div>

--- a/app/views/stats/_time.html.erb
+++ b/app/views/stats/_time.html.erb
@@ -3,10 +3,10 @@
   <div class="card-body">
     <div class="row">
       <div class="col-sm-6" style="min-height: 300px;">
-        <%= render_async time_refuge_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-time_refuge", src: time_refuge_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
       <div class="col-sm-6" style="min-height: 300px;">
-        <%= render_async time_mesophotic_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-time_mesophotic", src: time_mesophotic_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
     </div>
   </div>

--- a/app/views/stats/_world.html.erb
+++ b/app/views/stats/_world.html.erb
@@ -5,12 +5,12 @@
   <div class="card-body">
     <div class="row">
       <div class="col-sm-6" style="min-height: 430px;">
-        <%= render_async world_publications_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-world_publications", src: world_publications_path(:status => @status, :year => @year), loading: :lazy %>
         <br><br>
-        <%= render_async world_users_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-world_users", src: world_users_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
       <div class="col-sm-6" style="min-height: 600px;">
-        <%= render_async world_locations_path(:status => @status, :year => @year) %>
+        <%= turbo_frame_tag "stats-world_locations", src: world_locations_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
     </div>
   </div>

--- a/app/views/summary/_show.html.erb
+++ b/app/views/summary/_show.html.erb
@@ -40,7 +40,7 @@
         <strong>Research Keywords</strong>
       </div>
       <div class="card-body" style="min-height: 232px;">
-         <%= render_async summary_keywords_path(model: title.downcase, id: object.id) %>
+         <%= turbo_frame_tag "summary-keywords-#{title.downcase}-#{object.id}", src: summary_keywords_path(model: title.downcase, id: object.id), loading: :lazy %>
       </div>
     </div>
 
@@ -50,7 +50,7 @@
           <strong>Researchers</strong> (that published on this location)
         </div>
         <div class="card-body">
-          <%= render_async summary_researchers_path(model: title.downcase, id: object.id) %>
+          <%= turbo_frame_tag "summary-researchers-#{title.downcase}-#{object.id}", src: summary_researchers_path(model: title.downcase, id: object.id), loading: :lazy %>
         </div>
       </div>
     <% end %>
@@ -82,7 +82,7 @@
           <strong>Publication Summary</strong> (top 5 / category)
         </div>
         <div class="card-body">
-          <%= render_async summary_publications_path(model: title.downcase, id: object.id) %>
+          <%= turbo_frame_tag "summary-publications-#{title.downcase}-#{object.id}", src: summary_publications_path(model: title.downcase, id: object.id), loading: :lazy %>
         </div>
       </div>
     <% end %>

--- a/config/initializers/render_async.rb
+++ b/config/initializers/render_async.rb
@@ -1,4 +1,0 @@
-RenderAsync.configure do |config|
-  config.jquery = false
-  config.turbo = true
-end

--- a/gemset.nix
+++ b/gemset.nix
@@ -1318,16 +1318,6 @@
     };
     version = "0.6.3";
   };
-  render_async = {
-    groups = ["default"];
-    platforms = [];
-    source = {
-      remotes = ["https://rubygems.org"];
-      sha256 = "1pv6q9whsa5ywwpd6sah3nbhl2yn5lk9m4sgi9f8v4143r3cv0pv";
-      type = "gem";
-    };
-    version = "2.1.11";
-  };
   request_store = {
     dependencies = ["rack"];
     groups = ["default"];


### PR DESCRIPTION
## Summary

- Replace all 35 `render_async` calls across 8 controllers with native Turbo Frames (`turbo_frame_tag` with `src` and `loading: :lazy`)
- Add shared `render_in_turbo_frame` helper to ApplicationController for DRY controller responses
- Remove `render_async` gem, initializer, layout line, and legacy event listeners
- Existing caching (`Rails.cache.fetch`) preserved — turbo-frame wraps outside the cache

## Controllers converted

| Controller | Calls | Views |
|---|---|---|
| MapsController | 1 action, 9 view call sites | 9 partials |
| StatsController | 13 actions | 4 partials |
| SummaryController | 3 actions | 1 partial |
| PagesController | 4 actions | 2 views |
| PublicationsController | 2 actions | 1 view |
| SitesController | 2 actions | 1 view |
| SpeciesController | 1 action | 1 partial |

## Test plan

- [x] `rails test` — 183 tests, 0 failures
- [x] Home page: social feeds load, map loads
- [x] Stats page: all 13 charts render
- [x] Publication show: word cloud, author profiles, map load
- [x] Species page: species image loads with spinner
- [x] Summary pages: word cloud, researchers, publications load
- [x] Member page: keywords and research summary load
- [x] Site pages: keywords and research details load
- [x] No JS console errors