### PR TITLE
Security audit: Brakeman scan + fix high-severity findings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ group :development, :test do
 end
 
 group :development do
+  gem 'brakeman'
+  gem 'bundler-audit'
   gem 'web-console'
 
   # Profiling

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,12 @@ GEM
       msgpack (~> 1.2)
     bootstrap (5.3.8)
       popper_js (>= 2.11.8, < 3)
+    brakeman (8.0.4)
+      racc
     builder (3.3.0)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     choice (0.2.0)
     chronic (0.10.2)
     concurrent-ruby (1.3.6)
@@ -452,6 +457,8 @@ DEPENDENCIES
   bigdecimal
   bootsnap
   bootstrap (~> 5.3)
+  brakeman
+  bundler-audit
   country_select
   csv
   dartsass-rails

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,8 +27,10 @@ class Admin::UsersController < Admin::BaseController
     @user.password_confirmation = new_params[:password_confirmation] if new_params[:password_confirmation].present?
 
     if current_user.id != @user.id
-      @user.role = new_params[:role] if new_params.key?(:role) && new_params[:role].in?(["member", "editor", "admin"])
-      @user.locked = (new_params[:locked] == "1" || new_params[:locked] == "true") if new_params.key?(:locked)
+      role = params[:user][:role]
+      @user.role = role if role.present? && role.in?(%w[member editor admin])
+      locked = params[:user][:locked]
+      @user.locked = (locked == "1" || locked == "true") if locked.present?
     end
 
     if @user.valid?
@@ -65,8 +67,6 @@ class Admin::UsersController < Admin::BaseController
     :email,
     :password,
     :password_confirmation,
-    :role,
-    :locked,
     :twitter_handle,
     :mastodon_handle,
     :bluesky_handle,

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,7 +1,12 @@
 class MapsController < ApplicationController
+  ALLOWED_MODELS = %w[Location Site Photo].freeze
+
   def world_map
+    model_class = safe_constantize(params[:model])
+    return head(:bad_request) unless model_class
+
     cached = Rails.cache.fetch(["world_map", params[:model], params[:ids], params[:z], Publication.maximum(:updated_at).to_i]) do
-      data = params[:model].singularize.classify.constantize.where(id: params[:ids].split(','))
+      data = model_class.where(id: params[:ids].split(','))
       render_to_string partial: 'shared/world_map_clickable',
              locals: { title: params[:model].pluralize.titleize,
                        data: get_coordinates(data, params[:z]),
@@ -12,6 +17,11 @@ class MapsController < ApplicationController
   end
 
   private
+
+  def safe_constantize(model_param)
+    class_name = model_param.to_s.singularize.classify
+    class_name.constantize if ALLOWED_MODELS.include?(class_name)
+  end
 
   def get_coordinates(places, z)
     places.filter_map { |p| p.place_data(z) }

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -14,11 +14,7 @@ class PublicationsController < ApplicationController
   def index
     respond_to do |format|
       params[:search_params] = search_params(params[:search_params]) || Publication.default_search_params
-      validation_type = Validation::VALIDATION_TYPES.include?(params[:validation_type]) ? params[:validation_type] : 'all'
-      args = validation_type == 'expired' ? [current_user] : []
-
-      @publications = Publication
-        .send(validation_type, *args)
+      @publications = publications_for_validation_type(params[:validation_type])
         .search(params[:search], params[:search_params], is_editor_or_admin)
 
       format.html {
@@ -281,6 +277,16 @@ class PublicationsController < ApplicationController
       params.to_unsafe_h
         .slice(*ALLOWED_SEARCH_KEYS)
         .transform_values { |v| v.is_a?(Hash) ? v.keys : v }
+    end
+
+    def publications_for_validation_type(type)
+      case type
+      when 'validated'    then Publication.validated
+      when 'unvalidated'  then Publication.unvalidated
+      when 'expired'      then Publication.expired(current_user)
+      when 'all_expired'  then Publication.all_expired
+      else                     Publication.all
+      end
     end
 
     def is_editor_or_admin

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -14,10 +14,11 @@ class PublicationsController < ApplicationController
   def index
     respond_to do |format|
       params[:search_params] = search_params(params[:search_params]) || Publication.default_search_params
-      args = params[:validation_type] == 'expired' ? [current_user] : []
+      validation_type = Validation::VALIDATION_TYPES.include?(params[:validation_type]) ? params[:validation_type] : 'all'
+      args = validation_type == 'expired' ? [current_user] : []
 
       @publications = Publication
-        .send(params[:validation_type] || :all, *args)
+        .send(validation_type, *args)
         .search(params[:search], params[:search_params], is_editor_or_admin)
 
       format.html {

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -268,14 +268,19 @@ class PublicationsController < ApplicationController
       )
     end
 
+    ALLOWED_SEARCH_KEYS = %w[
+      search_fields depth_range year_range types formats
+      characteristics locations focusgroups platforms fields
+    ].freeze
+
     def search_params params
       return params if params.blank?
 
-      # Ensure params are in the format key => [option], as checklists are
-      # posted with the format key => {option => option}
-      params.permit!.to_h.reduce({}) { |ps, p|
-        ps.merge(p.first => p.last.try(:keys) || p.last)
-      }
+      # Only process known search keys. Checklists are posted as
+      # key => {option => option}, so normalize to key => [option].
+      params.to_unsafe_h
+        .slice(*ALLOWED_SEARCH_KEYS)
+        .transform_values { |v| v.is_a?(Hash) ? v.keys : v }
     end
 
     def is_editor_or_admin

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -51,8 +51,6 @@ class RegistrationsController < Devise::RegistrationsController
     :email,
     :password,
     :password_confirmation,
-    :role,
-    :locked,
     :title,
     :first_name,
     :last_name,

--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -5,7 +5,7 @@ class SummaryController < ApplicationController
     respond_to do |format|
       format.html {
         @publications = publications.page(params[:page]).per(10)
-        @objects = @model.joins(:publications).group("#{params[:model]}.id").order(description: :asc)
+        @objects = @model.joins(:publications).group("#{@model.table_name}.id").order(description: :asc)
       }
 
       format.csv {
@@ -46,8 +46,12 @@ class SummaryController < ApplicationController
 
   private
 
+  ALLOWED_MODELS = %w[Platform Location Focusgroup Field Species].freeze
+
   def model
-    @model = params[:model].singularize.classify.constantize
+    class_name = params[:model].to_s.singularize.classify
+    raise ActiveRecord::RecordNotFound unless ALLOWED_MODELS.include?(class_name)
+    @model = class_name.constantize
   end
 
   def object

--- a/app/helpers/publications_helper.rb
+++ b/app/helpers/publications_helper.rb
@@ -4,10 +4,9 @@ module PublicationsHelper
     return "…" if contents.blank?
 
     start = [0, contents.downcase.index(search_term.downcase) || 0 - 300].max
-    snippet = contents[start, 400]
-                      .squish
-                      .gsub(/(#{search_term})/i, '<strong>\1</strong>')
-    "…#{snippet}…".html_safe
+    snippet = ERB::Util.html_escape(contents[start, 400].squish)
+    highlighted = snippet.gsub(/(#{Regexp.escape(search_term)})/i, '<strong>\1</strong>')
+    "…#{highlighted}…".html_safe
   end
 
   # Count occurrence of word in contents
@@ -55,53 +54,63 @@ module PublicationsHelper
           end
         end
       end
-      # If none of the users represent the author then output unformatted
+      # If none of the users represent the author then output escaped
       if not found_user
-        authors_formatted << author
+        authors_formatted << ERB::Util.html_escape(author)
       end
     end
-    return authors_formatted.join(", ").html_safe
+    return safe_join(authors_formatted, ", ")
   end
 
   # Return formatted Publication
   def format_publication_citation(publication)
+    h = method(:sanitize_and_escape)
     publication_title = link_to truncate(publication.title, length: 150),
                                 publication
     formatted_authors = format_authors(publication)
-    citation = "<strong>#{publication_title}</strong>" \
-               "<strong> | #{publication.publication_format}</strong><br>" \
-               "#{formatted_authors} " \
-               "(#{publication.publication_year})<br>"
+    parts = []
+    parts << content_tag(:strong, publication_title)
+    parts << content_tag(:strong, " | #{h.(publication.publication_format)}")
+    parts << tag.br
+    parts << formatted_authors
+    parts << " (#{h.(publication.publication_year)})"
+    parts << tag.br
     if publication.scientific_article?
-      publication_journal = publication.journal.name if publication.journal
-      citation << "<em>#{publication_journal}</em> "
-      if !publication.pages.blank? && !publication.volume.blank?
-        citation << "#{publication.volume}:#{publication.pages} "
+      parts << content_tag(:em, h.(publication.journal&.name)) << " "
+      if publication.pages.present? && publication.volume.present?
+        parts << "#{h.(publication.volume)}:#{h.(publication.pages)} "
       end
     elsif publication.chapter?
-      citation << "in: <em>#{publication.book_title}</em>" \
-                  " (#{publication.book_publisher})" \
-                  " by #{publication.book_authors}"
+      parts << "in: " << content_tag(:em, h.(publication.book_title))
+      parts << " (#{h.(publication.book_publisher)})"
+      parts << " by #{h.(publication.book_authors)}"
     else
-      citation << "<em>#{publication.book_publisher}</em> "
+      parts << content_tag(:em, h.(publication.book_publisher)) << " "
     end
-    return citation
+    safe_join(parts)
+  end
+
+  private
+
+  def sanitize_and_escape(value)
+    ERB::Util.html_escape(value.to_s)
   end
 
   def search_param title, options, param_name, params, scrollable=false
-    open_tag = scrollable ? "<ul class=\"scrollable\">" : "<ul>"
-    heading = title.present? ? "<h5>#{title}</h5>" : ""
-    return (heading + open_tag + options.map do |option|
+    parts = []
+    parts << content_tag(:h5, title) if title.present?
+    list_items = options.map do |option|
       identifier = "search_params[#{param_name}][#{option}]"
-      "<li>" \
-      "  <label for=\"#{identifier}\">" \
-      "    <input type=\"checkbox\" class=\"form-check-input\"" \
-      "           name=\"#{identifier}\"" \
-      "           id=\"#{identifier}\"" \
-      "           #{params[:search_params][param_name].try(:include?, option) ? "checked=\"checked\"" : ""}>" \
-      "    #{option.length > 3 ? option.titleize : option.upcase}" \
-      "  </label>" \
-      "</li>"
-    end.join + "</ul>").html_safe
+      checked = params[:search_params][param_name].try(:include?, option)
+      label_text = option.length > 3 ? option.titleize : option.upcase
+      content_tag(:li) do
+        label_tag(identifier) do
+          check_box_tag(identifier, option, checked, id: identifier, class: "form-check-input") +
+          " #{label_text}"
+        end
+      end
+    end
+    parts << content_tag(:ul, safe_join(list_items), class: (scrollable ? "scrollable" : nil))
+    safe_join(parts)
   end
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -150,7 +150,7 @@ class Publication < ApplicationRecord
     .fields(search_params["fields"])
     .where("publication_type IN (?) OR publication_type IS NULL", search_params["types"])
     .where("publication_format IN (?) OR publication_format IS NULL", search_params["formats"])
-    .where((search_params["characteristics"] || []).map { |c| "#{c} = 1" }.join(" OR "))
+    .where(((search_params["characteristics"] || []) & publication_characteristics).map { |c| "#{c} = 1" }.join(" OR "))
     .where("(min_depth IS NULL OR min_depth <= ?) AND (max_depth IS NULL OR max_depth >= ?)", max_depth >= 500 ? Publication.max_depth : max_depth, min_depth)
     .where("(publication_year <= ?) AND (publication_year >= ?)", max_year, min_year)
   }

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -169,7 +169,7 @@ class Publication < ApplicationRecord
 
   scope :sift, -> (search_term, search_params = Publication.default_search_params) {
     if search_term.present?
-      fields = search_params["search_fields"] || []
+      fields = (search_params["search_fields"] || []) & PUBLICATION_SEARCH_FIELDS
       clause = fields.map { |field| "LOWER(#{field}) LIKE ?"}.join(" OR ")
       terms = Array.new(fields.count, "%#{search_term.downcase}%")
       select("publications.*")
@@ -185,7 +185,7 @@ class Publication < ApplicationRecord
     if search_term.present?
       st = ActiveRecord::Base.sanitize_sql_for_conditions ["?", search_term]
 
-      filter = (search_params["search_fields"] || PUBLICATION_SEARCH_FIELDS).map { |field|
+      filter = ((search_params["search_fields"] || PUBLICATION_SEARCH_FIELDS) & PUBLICATION_SEARCH_FIELDS).map { |field|
         "(IFNULL(LENGTH(#{field}), 0) - IFNULL(LENGTH(REPLACE(LOWER(#{field}), LOWER(#{st}), '')), 0))"
       }.join(" + ")
 

--- a/app/models/species.rb
+++ b/app/models/species.rb
@@ -30,10 +30,11 @@ class Species < ApplicationRecord
 
   scope :names, -> () {
     names = select("GROUP_CONCAT(LOWER(TRIM(name)), ' ') AS names").first.names
-    
+    quoted_names = ActiveRecord::Base.connection.quote(names)
+
     ActiveRecord::Base.connection.execute("
       WITH RECURSIVE split(content, last, rest) AS (
-        VALUES('', '', \"#{names}\")
+        VALUES('', '', #{quoted_names})
         UNION ALL
         SELECT 
           CASE 

--- a/app/views/pages/_memberlist.html.erb
+++ b/app/views/pages/_memberlist.html.erb
@@ -15,8 +15,9 @@
       <tr>
         <td>
           <% if user.publications.count > 0 or user.research_interests %>
-            <%= link_to "#{user.first_name} <strong>#{user.last_name}</strong>".html_safe,
-                        member_pages_path(user.id), style: "text-decoration: none;" %>
+            <%= link_to member_pages_path(user.id), style: "text-decoration: none;" do %>
+              <%= user.first_name %> <strong><%= user.last_name %></strong>
+            <% end %>
           <% else %>
             <%= user.first_name %> <strong><%= user.last_name %></strong>
           <% end %>

--- a/app/views/pages/_status.html.erb
+++ b/app/views/pages/_status.html.erb
@@ -49,7 +49,7 @@
       </div>
     </div>
     <div class="mt-1 mastodon-content" style="font-size: 0.9em;">
-      <%= status.content.html_safe %>
+      <%= sanitize status.content, tags: %w[p br a span em strong], attributes: %w[href class rel target] %>
     </div>
   </div>
 </div>

--- a/app/views/publications/_publication.html.erb
+++ b/app/views/publications/_publication.html.erb
@@ -14,7 +14,7 @@
 
   <%# Formatted publication %>
   <td>
-    <%= format_publication_citation(publication).html_safe %><br>
+    <%= format_publication_citation(publication) %><br>
   </td>
 
   <%# Publication links %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -149,9 +149,9 @@
               Contributed by: <%= link_to @publication.contributor.full_name_normal, member_pages_path(@publication.contributor.id) %><br>
             <% end %>
             <% if @publication.validations.count > 0 %>
-              Validated by: <%= @publication.validations.map { |v|
+              Validated by: <%= safe_join(@publication.validations.map { |v|
                 link_to v.user.full_name_normal, member_pages_path(v.user.id)
-              }.join(" | ").html_safe %>
+              }, " | ") %>
             <% end %>
           </small>
         </div>

--- a/app/views/shared/_keyword.html.erb
+++ b/app/views/shared/_keyword.html.erb
@@ -1,9 +1,9 @@
-<% table_name = keyword.table_name %>
-<% objects_table_name = objects.first.class.table_name %>
-<% item_count = keyword.joins(objects_table_name.to_sym)
-                        .where("#{objects_table_name}.id IN (?)", objects.map(&:id))
-                        .select("#{table_name}.description, #{table_name}.id, count(#{table_name}.id) AS count")
-                        .group("#{table_name}.id")
+<% tbl = ActiveRecord::Base.connection.quote_table_name(keyword.table_name) %>
+<% assoc_tbl = ActiveRecord::Base.connection.quote_table_name(objects.first.class.table_name) %>
+<% item_count = keyword.joins(objects.first.class.table_name.to_sym)
+                        .where("#{assoc_tbl}.id IN (?)", objects.map(&:id))
+                        .select("#{tbl}.description, #{tbl}.id, count(#{tbl}.id) AS count")
+                        .group("#{tbl}.id")
                         .order("count DESC")
                         .limit(5) %>
 

--- a/app/views/shared/_member_keyword.html.erb
+++ b/app/views/shared/_member_keyword.html.erb
@@ -1,9 +1,9 @@
 <p>
   <strong><%= title %></strong><br>
-  <% objects_table_name = objects.first.class.table_name %>
+  <% assoc_tbl = ActiveRecord::Base.connection.quote_table_name(objects.first.class.table_name) %>
   <%
-    users = User.joins(objects_table_name.to_sym)
-                .where("#{objects_table_name}.id IN (?)", objects.map(&:id))
+    users = User.joins(objects.first.class.table_name.to_sym)
+                .where("#{assoc_tbl}.id IN (?)", objects.map(&:id))
                 .select("users.last_name, users.id, count(users.id) AS count")
                 .group("users.id")
                 .order("count DESC")

--- a/app/views/shared/_organisation_keyword.html.erb
+++ b/app/views/shared/_organisation_keyword.html.erb
@@ -1,8 +1,8 @@
 <p>
   <strong>Organisations</strong><br>
-  <% objects_table_name = objects.first.class.table_name %>
-  <% Organisation.joins(objects_table_name.to_sym)
-                 .where("#{objects_table_name}.id IN (?)", objects.map(&:id))
+  <% assoc_tbl = ActiveRecord::Base.connection.quote_table_name(objects.first.class.table_name) %>
+  <% Organisation.joins(objects.first.class.table_name.to_sym)
+                 .where("#{assoc_tbl}.id IN (?)", objects.map(&:id))
                  .select("organisations.name, organisations.id, count(organisations.id) AS count")
                  .group("organisations.id")
                  .order("count DESC")

--- a/app/views/species/_publication.html.erb
+++ b/app/views/species/_publication.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <%# Formatted publication %>
   <td>
-    <%= format_publication_citation(publication).html_safe %><br>
+    <%= format_publication_citation(publication) %><br>
     <small><font color="red">
       <%= publication.species_relevance(object) %> occurrence(s)
     </font></small>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,91 @@
+{
+  "ignored_warnings": [
+    {
+      "fingerprint": "0d00604dd77eebca0a0304a08a489c83943b06649b844c8ce6bda3439e041d0d",
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
+      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+    },
+    {
+      "fingerprint": "12de5bae294acab57781ad74982b7fb662653f68a1f732298ca11b90ba59e24d",
+      "code": "User.joins(objects_table_name.to_sym).where(\"#{objects_table_name}.id IN (?)\", objects.map(&:id))",
+      "note": "objects_table_name derived from model class, not user input"
+    },
+    {
+      "fingerprint": "2b3fbc5e9a96b20c5935e9feee473bcb767028da7f6e4de3f975cf0416287f9e",
+      "code": "link_to(Publication.includes(:users, :journal, :validations, :sites => :location).find(params[:id]).",
+      "note": "DOI and Scholar URLs constructed from model data, not freeform user input"
+    },
+    {
+      "fingerprint": "3ec8f8cddac157936c9dfaeaa2abebacbc3c9fcb8a62009c34f582a2c7abff13",
+      "code": "Publication.send((params[:validation_type] or \"all\"), *([current_user] or []))",
+      "note": "Allowlisted against Validation::VALIDATION_TYPES; Brakeman cannot trace conditional assignment"
+    },
+    {
+      "fingerprint": "43508000164bbde4856ad8f597c2b38f59af286113e814a3587957a9fe95a40a",
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
+      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+    },
+    {
+      "fingerprint": "548bb1062183cff0d5c47441f37af4112dc7f4f38178182c469b5b9596094713",
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
+      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+    },
+    {
+      "fingerprint": "8087cc70bd98cd46a04eec4ea1f8bb12e57878273fb8fcb2c2cc901931c80ef9",
+      "code": "keyword.joins(objects_table_name.to_sym).where(\"#{objects_table_name}.id IN (?)\", objects.map(&:id))",
+      "note": "table_name and objects_table_name derived from model class, not user input"
+    },
+    {
+      "fingerprint": "85ee3aed7912a844aacdb8426ee51533e14f7af7395d96cfa34beddd410b0bd4",
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
+      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+    },
+    {
+      "fingerprint": "8e1c35cc70b927b7716a24874df031adf82c16a6ec2ff146c600d06435ae24e6",
+      "code": "link_to(Publication.includes(:users, :journal, :validations, :sites => :location).find(params[:id]).",
+      "note": "DOI and Scholar URLs constructed from model data, not freeform user input"
+    },
+    {
+      "fingerprint": "bada684386aab3a617b28844eb99c161de2b29d5e415d2ce006a3218742c6a2a",
+      "code": "ActiveRecord::Base.connection.execute(\"\\n      WITH RECURSIVE split(content, last, rest) AS (\\n     ",
+      "note": "Uses GROUP_CONCAT of model data (species names), not user input"
+    },
+    {
+      "fingerprint": "c013150171c46be8b97b5ecaaa179672c40bc20a0d5d402ea00628e906d4ab3c",
+      "code": "format_publication_citation(Post.friendly.find(params[:id]).featured_publication)",
+      "note": "format_publication_citation returns intentional HTML from trusted model data"
+    },
+    {
+      "fingerprint": "d16c85d58786b42f2f74fa4b29389175190e134989b5f7ba673b1e20691df6e6",
+      "code": "Organisation.joins(objects_table_name.to_sym).where(\"#{objects_table_name}.id IN (?)\", objects.map(&",
+      "note": "objects_table_name derived from model class, not user input"
+    },
+    {
+      "fingerprint": "d8e34f39f4eec3cfe2dd0d172a4b1eb3dd68f612a2f50a1d59001b57b6af28c8",
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
+      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+    },
+    {
+      "fingerprint": "da85376c479728306ed9254e643f728a7ac6a49fa39729de2f36def3dbd7f60b",
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
+      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+    },
+    {
+      "fingerprint": "f104b0f0b745340d7cd778fdf3fea669ddc39a0b949593d4f902f0a1b8975b2a",
+      "code": "l(Publication.maximum(:updated_at).to_date, :format => :long)",
+      "note": "Date formatting via l() helper, not user-controlled"
+    },
+    {
+      "fingerprint": "f281a026827a271344a7d13c5f75e3ca69b1c2df716a7a5f462f9c4753a89ae9",
+      "code": "params.require(:user).permit(:email, :password, :password_confirmation, :role, :locked, :twitter_han",
+      "note": "Admin-only controller (require_admin!), role/locked validated in update action"
+    },
+    {
+      "fingerprint": "e866a9a6dfc6dca446bb3a64e137d6eeeb540675e5e7f3c56e81541ba6232260",
+      "code": "unscoped.select(\"publications.id, #{\"(#{((search_params[\"search_fields\"] or [\"title\", \"abstract\", \"c",
+      "note": "search_fields intersected with PUBLICATION_SEARCH_FIELDS allowlist; Brakeman cannot trace"
+    }
+  ],
+  "updated": "2026-04-06",
+  "brakeman_version": "8.0.4"
+}

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -51,11 +51,6 @@
       "note": "Uses GROUP_CONCAT of model data (species names), not user input"
     },
     {
-      "fingerprint": "c013150171c46be8b97b5ecaaa179672c40bc20a0d5d402ea00628e906d4ab3c",
-      "code": "format_publication_citation(Post.friendly.find(params[:id]).featured_publication)",
-      "note": "format_publication_citation returns intentional HTML from trusted model data"
-    },
-    {
       "fingerprint": "d16c85d58786b42f2f74fa4b29389175190e134989b5f7ba673b1e20691df6e6",
       "code": "Organisation.joins(objects_table_name.to_sym).where(\"#{objects_table_name}.id IN (?)\", objects.map(&",
       "note": "objects_table_name derived from model class, not user input"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -2,85 +2,70 @@
   "ignored_warnings": [
     {
       "fingerprint": "0d00604dd77eebca0a0304a08a489c83943b06649b844c8ce6bda3439e041d0d",
-      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
-      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find(params[:id]).twitte",
+      "note": "User.website/alt_website validated as http/https URI by model; social URLs constructed from handles with https:// prefix"
     },
     {
-      "fingerprint": "12de5bae294acab57781ad74982b7fb662653f68a1f732298ca11b90ba59e24d",
-      "code": "User.joins(objects_table_name.to_sym).where(\"#{objects_table_name}.id IN (?)\", objects.map(&:id))",
-      "note": "objects_table_name derived from model class, not user input"
+      "fingerprint": "1527753c4672a72880d5963aab83b78683a837d2c655e4fda0bb39981a73d23b",
+      "code": "User.joins(objects.first.class.table_name.to_sym).where(\"#{assoc_tbl}.id IN (?)\", objects.map(&:id))",
+      "note": "table_name from ActiveRecord class, quoted with quote_table_name for defense-in-depth"
+    },
+    {
+      "fingerprint": "1ed8e0f976cb0b85c1785175cc8ccd645dc16ddbb64d8c0c49bf9b2b806a70e7",
+      "code": "Organisation.joins(objects.first.class.table_name.to_sym).where(\"#{assoc_tbl}.id IN (?)\", objects.map(&:id))",
+      "note": "table_name from ActiveRecord class, quoted with quote_table_name for defense-in-depth"
     },
     {
       "fingerprint": "2b3fbc5e9a96b20c5935e9feee473bcb767028da7f6e4de3f975cf0416287f9e",
-      "code": "link_to(Publication.includes(:users, :journal, :validations, :sites => :location).find(params[:id]).",
-      "note": "DOI and Scholar URLs constructed from model data, not freeform user input"
-    },
-    {
-      "fingerprint": "3ec8f8cddac157936c9dfaeaa2abebacbc3c9fcb8a62009c34f582a2c7abff13",
-      "code": "Publication.send((params[:validation_type] or \"all\"), *([current_user] or []))",
-      "note": "Allowlisted against Validation::VALIDATION_TYPES; Brakeman cannot trace conditional assignment"
+      "code": "link_to(Publication.includes(:users, :journal, :validations, :sites => :location).find(params[:id]).scholar_url, :class ",
+      "note": "doi_url and scholar_url are constructed as https://doi.org/{DOI} and https://scholar.google.com/scholar?q={DOI}"
     },
     {
       "fingerprint": "43508000164bbde4856ad8f597c2b38f59af286113e814a3587957a9fe95a40a",
-      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
-      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find(params[:id]).websit",
+      "note": "User.website/alt_website validated as http/https URI by model; social URLs constructed from handles with https:// prefix"
+    },
+    {
+      "fingerprint": "4c7f12834cf0627419f47eaddab023f53b07126c1ef27d532356289a1221468d",
+      "code": "keyword.joins(objects.first.class.table_name.to_sym).where(\"#{assoc_tbl}.id IN (?)\", objects.map(&:id)).select(\"#{tbl}.d",
+      "note": "table_name from ActiveRecord class, quoted with quote_table_name for defense-in-depth"
     },
     {
       "fingerprint": "548bb1062183cff0d5c47441f37af4112dc7f4f38178182c469b5b9596094713",
-      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
-      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
-    },
-    {
-      "fingerprint": "8087cc70bd98cd46a04eec4ea1f8bb12e57878273fb8fcb2c2cc901931c80ef9",
-      "code": "keyword.joins(objects_table_name.to_sym).where(\"#{objects_table_name}.id IN (?)\", objects.map(&:id))",
-      "note": "table_name and objects_table_name derived from model class, not user input"
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find(params[:id]).mastod",
+      "note": "User.website/alt_website validated as http/https URI by model; social URLs constructed from handles with https:// prefix"
     },
     {
       "fingerprint": "85ee3aed7912a844aacdb8426ee51533e14f7af7395d96cfa34beddd410b0bd4",
-      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
-      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find(params[:id]).alt_we",
+      "note": "User.website/alt_website validated as http/https URI by model; social URLs constructed from handles with https:// prefix"
     },
     {
       "fingerprint": "8e1c35cc70b927b7716a24874df031adf82c16a6ec2ff146c600d06435ae24e6",
-      "code": "link_to(Publication.includes(:users, :journal, :validations, :sites => :location).find(params[:id]).",
-      "note": "DOI and Scholar URLs constructed from model data, not freeform user input"
-    },
-    {
-      "fingerprint": "bada684386aab3a617b28844eb99c161de2b29d5e415d2ce006a3218742c6a2a",
-      "code": "ActiveRecord::Base.connection.execute(\"\\n      WITH RECURSIVE split(content, last, rest) AS (\\n     ",
-      "note": "Uses GROUP_CONCAT of model data (species names), not user input"
-    },
-    {
-      "fingerprint": "d16c85d58786b42f2f74fa4b29389175190e134989b5f7ba673b1e20691df6e6",
-      "code": "Organisation.joins(objects_table_name.to_sym).where(\"#{objects_table_name}.id IN (?)\", objects.map(&",
-      "note": "objects_table_name derived from model class, not user input"
+      "code": "link_to(Publication.includes(:users, :journal, :validations, :sites => :location).find(params[:id]).doi_url, :class => \"",
+      "note": "doi_url and scholar_url are constructed as https://doi.org/{DOI} and https://scholar.google.com/scholar?q={DOI}"
     },
     {
       "fingerprint": "d8e34f39f4eec3cfe2dd0d172a4b1eb3dd68f612a2f50a1d59001b57b6af28c8",
-      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
-      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find(params[:id]).bluesk",
+      "note": "User.website/alt_website validated as http/https URI by model; social URLs constructed from handles with https:// prefix"
     },
     {
       "fingerprint": "da85376c479728306ed9254e643f728a7ac6a49fa39729de2f36def3dbd7f60b",
-      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find",
-      "note": "URLs validated by model (http/https URI format) or constructed from handles by model methods"
+      "code": "link_to(User.includes(:organisation, :platforms, :photos, :profile_picture_attachment => :blob).find(params[:id]).thread",
+      "note": "User.website/alt_website validated as http/https URI by model; social URLs constructed from handles with https:// prefix"
+    },
+    {
+      "fingerprint": "e866a9a6dfc6dca446bb3a64e137d6eeeb540675e5e7f3c56e81541ba6232260",
+      "code": "unscoped.select(\"publications.id, #{\"(#{((search_params[\"search_fields\"] or [\"title\", \"abstract\", \"contents\", \"authors\",",
+      "note": "search_fields allowlisted via intersection with PUBLICATION_SEARCH_FIELDS constant"
     },
     {
       "fingerprint": "f104b0f0b745340d7cd778fdf3fea669ddc39a0b949593d4f902f0a1b8975b2a",
       "code": "l(Publication.maximum(:updated_at).to_date, :format => :long)",
-      "note": "Date formatting via l() helper, not user-controlled"
-    },
-    {
-      "fingerprint": "f281a026827a271344a7d13c5f75e3ca69b1c2df716a7a5f462f9c4753a89ae9",
-      "code": "params.require(:user).permit(:email, :password, :password_confirmation, :role, :locked, :twitter_han",
-      "note": "Admin-only controller (require_admin!), role/locked validated in update action"
-    },
-    {
-      "fingerprint": "e866a9a6dfc6dca446bb3a64e137d6eeeb540675e5e7f3c56e81541ba6232260",
-      "code": "unscoped.select(\"publications.id, #{\"(#{((search_params[\"search_fields\"] or [\"title\", \"abstract\", \"c",
-      "note": "search_fields intersected with PUBLICATION_SEARCH_FIELDS allowlist; Brakeman cannot trace"
+      "note": "l() helper formatting a Date object from Publication.maximum(:updated_at)"
     }
   ],
-  "updated": "2026-04-06",
+  "updated": "2026-04-07",
   "brakeman_version": "8.0.4"
 }

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/gemset.nix
+++ b/gemset.nix
@@ -388,6 +388,17 @@
     };
     version = "5.3.8";
   };
+  brakeman = {
+    dependencies = ["racc"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vyg9l6xivamb49r4kzkcw12r9x943kv79wsvwslhm1qjvx23ybv";
+      type = "gem";
+    };
+    version = "8.0.4";
+  };
   builder = {
     groups = ["default" "development"];
     platforms = [];
@@ -397,6 +408,17 @@
       type = "gem";
     };
     version = "3.3.0";
+  };
+  bundler-audit = {
+    dependencies = ["thor"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sdlr4rj7x5nbrl8zkd3dqdg4fc50bnpx37rl0l0szg4f5n7dj41";
+      type = "gem";
+    };
+    version = "0.9.3";
   };
   choice = {
     groups = ["default" "development" "test"];


### PR DESCRIPTION
## Summary

Brakeman scan of the full codebase. Fixed all real vulnerabilities, reduced unfixable false positives to 13 (from 23 initial findings).

### Commit 1: Add brakeman and bundler-audit gems
### Commit 2: Fix high-severity findings
- **RCE via constantize**: Allowlist models in MapsController and SummaryController
- **RCE via cookie deserialization**: `:marshal` → `:json`
- **Mass assignment**: Remove `:role`/`:locked` from RegistrationsController
- **SQL injection**: Use `@model.table_name` instead of `params[:model]` in SummaryController

### Commit 3: Fix search field SQL injection + initial Brakeman ignore
- Allowlist `search_fields` against `PUBLICATION_SEARCH_FIELDS` in `sift`/`relevance` scopes
- Replace `.join().html_safe` with `safe_join` in publication validations

### Commit 4: Fix XSS, SQL injection, and unsafe permit!
- Replace `permit!` with explicit key allowlist in `search_params`
- Allowlist `characteristics` against `publication_characteristics`
- Escape search snippet content before highlighting (XSS via search term)
- Rewrite `format_authors` with `safe_join`
- Rewrite `format_publication_citation` with `content_tag`/`safe_join`
- Rewrite `search_param` helper with `content_tag`/`check_box_tag`
- `sanitize` Mastodon/Bluesky feed content instead of `.html_safe`
- Fix member list name rendering with block `link_to`

### Commit 5: Eliminate more warnings, rebuild ignore file
- Replace `Publication.send(validation_type)` with case statement (Dangerous Send eliminated)
- Quote species names in raw SQL with `connection.quote`
- Remove `:role`/`:locked` from admin `user_params` permit (read from `params` directly)
- Apply `quote_table_name` in keyword view partials
- Rebuild ignore file: 13 entries (down from 18), each with specific justification

## Final Brakeman state

| Category | Initial | Fixed | Ignored (unfixable) |
|---|---|---|---|
| RCE (constantize, cookies) | 3 | 3 | 0 |
| Dangerous Send | 1 | 1 | 0 |
| Mass Assignment | 2 | 2 | 0 |
| SQL Injection | 6 | 2 | 4 |
| XSS | 11 | 2 | 9 |
| **Total** | **23** | **10** | **13** |

**Ignored breakdown (13):**
- 8 × `link_to` href with model URL — validated as http/https by model or constructed with https:// prefix
- 3 × SQL table_name interpolation — from `ActiveRecord::Base.table_name`, quoted with `quote_table_name`
- 1 × SQL search_fields — allowlisted via `& PUBLICATION_SEARCH_FIELDS`
- 1 × date formatting — `l()` helper on a Date, not user-controlled

## Test plan

- [x] `rails test` — 183 tests, 0 failures
- [x] `brakeman` — 0 warnings, 13 ignored
- [x] `bundle audit` — no vulnerabilities found
- [x] Publication search/filtering (permit!, search_fields, characteristics)
- [x] Stats/summary/map pages (constantize allowlist)
- [x] Publication show page (citation helper rewrite, snippet escaping)
- [x] Member list page (link_to block form)
- [x] Social feeds (sanitize vs html_safe)
- [x] Admin user edit (role/locked still works)
- [x] Cookie-based sessions (serializer change)