### PR TITLE
Fix Turbo Frame links showing 'Content missing'

### DIFF
--- a/app/views/pages/show_member.html.erb
+++ b/app/views/pages/show_member.html.erb
@@ -90,7 +90,7 @@
       <div class="card">
         <div class="card-header"><strong>Research Keywords</strong></div>
         <div class="card-body" style="min-height: 232px;">
-          <%= turbo_frame_tag "member-keywords-#{@user.id}", src: member_keywords_path(id: @user.id), loading: :lazy %>
+          <%= turbo_frame_tag "member-keywords-#{@user.id}", src: member_keywords_path(id: @user.id), loading: :lazy, target: "_top" %>
         </div>
       </div>
     <% end %>
@@ -131,7 +131,7 @@
       <div class="card">
         <div class="card-header"><strong>Research Summary</strong></div>
         <div class="card-body">
-          <%= turbo_frame_tag "member-research-summary-#{@user.id}", src: member_research_summary_path(id: @user.id), loading: :lazy %>
+          <%= turbo_frame_tag "member-research-summary-#{@user.id}", src: member_research_summary_path(id: @user.id), loading: :lazy, target: "_top" %>
         </div>
       </div>
     <% end %>

--- a/app/views/publications/show.html.erb
+++ b/app/views/publications/show.html.erb
@@ -163,7 +163,7 @@
       <div class="card">
         <div class="card-header"><strong>Author Profiles</strong></div>
         <div class="card-body">
-          <%= turbo_frame_tag "publication-authors-#{@publication.id}", src: publication_authors_path(id: @publication.id), loading: :lazy %>
+          <%= turbo_frame_tag "publication-authors-#{@publication.id}", src: publication_authors_path(id: @publication.id), loading: :lazy, target: "_top" %>
         </div>
       </div>
     <% end %>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -35,7 +35,7 @@
           <strong>Research details</strong> (top 5 / category)
         </div>
         <div class="card-body">
-          <%= turbo_frame_tag "site-research-details-#{@site.id}", src: site_research_details_path(id: @site.id), loading: :lazy %>
+          <%= turbo_frame_tag "site-research-details-#{@site.id}", src: site_research_details_path(id: @site.id), loading: :lazy, target: "_top" %>
         </div>
       </div>
     <% end %>

--- a/app/views/summary/_show.html.erb
+++ b/app/views/summary/_show.html.erb
@@ -40,7 +40,7 @@
         <strong>Research Keywords</strong>
       </div>
       <div class="card-body" style="min-height: 232px;">
-         <%= turbo_frame_tag "summary-keywords-#{title.downcase}-#{object.id}", src: summary_keywords_path(model: title.downcase, id: object.id), loading: :lazy %>
+         <%= turbo_frame_tag "summary-keywords-#{title.downcase}-#{object.id}", src: summary_keywords_path(model: title.downcase, id: object.id), loading: :lazy, target: "_top" %>
       </div>
     </div>
 
@@ -50,7 +50,7 @@
           <strong>Researchers</strong> (that published on this location)
         </div>
         <div class="card-body">
-          <%= turbo_frame_tag "summary-researchers-#{title.downcase}-#{object.id}", src: summary_researchers_path(model: title.downcase, id: object.id), loading: :lazy %>
+          <%= turbo_frame_tag "summary-researchers-#{title.downcase}-#{object.id}", src: summary_researchers_path(model: title.downcase, id: object.id), loading: :lazy, target: "_top" %>
         </div>
       </div>
     <% end %>
@@ -82,7 +82,7 @@
           <strong>Publication Summary</strong> (top 5 / category)
         </div>
         <div class="card-body">
-          <%= turbo_frame_tag "summary-publications-#{title.downcase}-#{object.id}", src: summary_publications_path(model: title.downcase, id: object.id), loading: :lazy %>
+          <%= turbo_frame_tag "summary-publications-#{title.downcase}-#{object.id}", src: summary_publications_path(model: title.downcase, id: object.id), loading: :lazy, target: "_top" %>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
## Summary

- Add `target: "_top"` to 7 lazy-loaded Turbo Frames that contain navigation links
- Without this, clicking a link inside a frame tries to navigate within the frame, fails to find a matching `<turbo-frame>` in the response, and shows "Content missing"

## Affected pages

- Summary pages (locations, fields, focusgroups, platforms, species): keywords, researchers, publication summary links
- Publication show: author profile links
- Member show: keyword wordcloud clicks, research summary links
- Site show: research detail links

## Test plan

- [x] `rails test` — 183 tests, 0 failures
- [x] Summary page sidebar: researcher names, focusgroup/field/platform links navigate correctly
- [x] Publication show: author profile links work
- [x] Member show: research summary links work
- [x] Site show: research detail links work