### PR TITLE
Add bullet gem for N+1 detection, fix 3 N+1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ end
 # RailsBricks development gems
 group :development, :test do
   gem 'annotate'
+  gem 'bullet'
   gem 'debug'
   gem 'minitest', '~> 5.0'
   gem 'rails-erd'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,9 @@ GEM
     brakeman (8.0.4)
       racc
     builder (3.3.0)
+    bullet (8.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
@@ -424,6 +427,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unaccent (0.4.0)
+    uniform_notifier (1.18.0)
     uri (1.1.1)
     useragent (0.16.11)
     warden (1.2.9)
@@ -458,6 +462,7 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 5.3)
   brakeman
+  bullet
   bundler-audit
   country_select
   csv

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -59,6 +59,7 @@ class PublicationsController < ApplicationController
   end
 
   def show
+    @publication = Publication.includes(:users, :journal, { validations: :user }, sites: :location).find(params[:id])
   end
 
   def behind
@@ -177,7 +178,7 @@ class PublicationsController < ApplicationController
 
   private
     def set_publication
-      @publication = Publication.includes(:users, :journal, { validations: :user }, sites: :location).find(params[:id])
+      @publication = Publication.find(params[:id])
     rescue
       redirect_back fallback_location: publications_path
     end

--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -177,7 +177,7 @@ class PublicationsController < ApplicationController
 
   private
     def set_publication
-      @publication = Publication.includes(:users, :journal, :validations, sites: :location).find(params[:id])
+      @publication = Publication.includes(:users, :journal, { validations: :user }, sites: :location).find(params[:id])
     rescue
       redirect_back fallback_location: publications_path
     end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -55,6 +55,7 @@ class StatsController < ApplicationController
   end
 
   def growing_locations_over_time
+    @publications = @publications.includes(:locations)
     render_in_turbo_frame("stats-growing_locations_over_time") { render_to_string partial: "growing_locations_over_time" }
   end
 
@@ -111,6 +112,7 @@ class StatsController < ApplicationController
   end
 
   def world_publications
+    @publications = @publications.includes(:locations)
     render_in_turbo_frame("stats-world_publications") { render_to_string partial: "world_publications" }
   end
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,26 +42,21 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # Bullet N+1 detection
+  # Bullet N+1 detection — raises on any unoptimized query in tests
   config.after_initialize do
     Bullet.enable = true
     Bullet.raise = true
 
-    # Shared set_publication loads associations needed by show but not edit/delete
-    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :users
+    # HABTM join tables flagged as unused when the parent association is used
     Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :publications_users
-    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :journal
-    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :validations
-    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :sites
-    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :publications_sites
-    Bullet.add_safelist type: :unused_eager_loading, class_name: "Validation", association: :user
 
-    # show_member/about includes associations for conditional rendering;
-    # bullet flags as unused when fixture user has none
-    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :platforms
-    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :platforms_users
+    # Photos require Active Storage attachments which are complex to fixture
     Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :photos
     Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :photos_users
+
+    # About page eager loads organisation/profile_picture for contributor
+    # partial, but fixture users don't match the hardcoded contributor
+    # names in the template, so the associations appear unused in tests.
     Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :organisation
     Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :profile_picture_attachment
   end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,28 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Bullet N+1 detection
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.raise = true
+
+    # Shared set_publication loads associations needed by show but not edit/delete
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :users
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :publications_users
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :journal
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :validations
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :sites
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Publication", association: :publications_sites
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "Validation", association: :user
+
+    # show_member/about includes associations for conditional rendering;
+    # bullet flags as unused when fixture user has none
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :platforms
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :platforms_users
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :photos
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :photos_users
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :organisation
+    Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :profile_picture_attachment
+  end
 end

--- a/gemset.nix
+++ b/gemset.nix
@@ -409,6 +409,17 @@
     };
     version = "3.3.0";
   };
+  bullet = {
+    dependencies = ["activesupport" "uniform_notifier"];
+    groups = ["development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zwq7g98c1mdigahb50c980a0fcc4ib1m9ivmgf3f8gc6qk7wjv0";
+      type = "gem";
+    };
+    version = "8.1.0";
+  };
   bundler-audit = {
     dependencies = ["thor"];
     groups = ["development"];
@@ -1557,6 +1568,16 @@
       type = "gem";
     };
     version = "0.4.0";
+  };
+  uniform_notifier = {
+    groups = ["default" "development"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17ffzyq6482yn27r7rz2k3zslf9jigbz383d90c68vznarapi1s7";
+      type = "gem";
+    };
+    version = "1.18.0";
   };
   uri = {
     groups = ["default" "development" "test"];

--- a/test/fixtures/publications.yml
+++ b/test/fixtures/publications.yml
@@ -87,6 +87,7 @@ scientific_article:
   focusgroups: corals
   platforms: scuba, rov
   locations: great_barrier_reef
+  sites: osprey_reef
 
 stats_ecology_gbr:
   title: "Ecology of mesophotic reefs at the Great Barrier Reef"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -7,6 +7,9 @@ admin_user:
   locked: false
   confirmed_at: "2024-01-01 00:00:00"
   organisation: csiro
+  platforms: scuba, rov
+  photos: cc_photo
+  publications: scientific_article
 
 editor_user:
   email: "editor@example.com"
@@ -25,6 +28,8 @@ regular_user:
   role: "member"
   locked: false
   confirmed_at: "2024-01-01 00:00:00"
+  platforms: scuba
+  publications: scientific_article
 
 locked_user:
   email: "locked@example.com"


### PR DESCRIPTION
## Summary

- Add bullet gem to development + test, raises on N+1 in tests
- Fix 3 N+1 queries detected by bullet
- Enrich fixtures to exercise eager-loaded associations
- Move heavy includes from shared `set_publication` to `show` action only

### N+1 fixes

| Controller | Action | Fix |
|---|---|---|
| StatsController | world_publications | Add `.includes(:locations)` |
| StatsController | growing_locations_over_time | Add `.includes(:locations)` |
| PublicationsController | show | Eager load `validations: :user`, move includes from `set_publication` to `show` |

### Fixture improvements

- `regular_user`: add platforms + publications
- `admin_user`: add platforms + photos + publications
- `scientific_article`: add sites association

## Test plan

- [x] `rails test` — 210 tests, 445 assertions, 0 failures, 0 errors
- [x] Bullet raises on any new N+1 going forward
- [x] Stats page: world map and locations-over-time charts render
- [x] Publication show: "Validated by" section loads without extra queries
- [x] Member page: platforms and publications render