### PR TITLE
Fix photos metadata summary to show all photos (fixes #102)

### DIFF
--- a/app/controllers/photos_controller.rb
+++ b/app/controllers/photos_controller.rb
@@ -8,6 +8,7 @@ class PhotosController < ApplicationController
 
   def index
     @photos = Photo.all.order(id: :desc).page(params[:page])
+    @all_photos = Photo.all
     @location_counts = Location.joins(:photos)
                                .group('locations.id')
                                .select('locations.*, count(locations.id) as item_count')

--- a/app/views/photos/index.html.erb
+++ b/app/views/photos/index.html.erb
@@ -27,10 +27,12 @@
     <div class="card">
       <div class="card-header"><strong>Image Locations</strong></div>
       <div class="card-body" align="center">
-        <% data = format_counts_for_world_map(@location_counts) %>
-        <%= render partial: 'shared/world_map', locals: { title: 'Locations',
-                                                          data: data,
-                                                          height: 150 } %>
+        <% cache ["photos_location_map", Photo.maximum(:updated_at)] do %>
+          <% data = format_counts_for_world_map(@location_counts) %>
+          <%= render partial: 'shared/world_map', locals: { title: 'Locations',
+                                                            data: data,
+                                                            height: 150 } %>
+        <% end %>
       </div>
     </div>
 
@@ -40,13 +42,15 @@
         <strong>Images metadata summary</strong> (top 5 / category)
       </div>
       <div class="card-body">
-        <%= render partial: 'shared/keyword',
-                   locals: { objects: @photos },
-                   collection: [Location, Platform] %>
-        <%= render partial: 'shared/organisation_keyword',
-                   locals: { objects: @photos } %>
-        <%= render partial: 'shared/member_keyword',
-                   locals: { title: "Researchers", objects: @photos } %>
+        <% cache ["photos_metadata_summary", Photo.maximum(:updated_at)] do %>
+          <%= render partial: 'shared/keyword',
+                     locals: { objects: @all_photos },
+                     collection: [Location, Platform] %>
+          <%= render partial: 'shared/organisation_keyword',
+                     locals: { objects: @all_photos } %>
+          <%= render partial: 'shared/member_keyword',
+                     locals: { title: "Researchers", objects: @all_photos } %>
+        <% end %>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

The "Images metadata summary (top 5 / category)" sidebar on `/photos` only summarised the current paginated page (~25 photos) instead of the full image bank.

**Before:** Summary changes on every page, dominated by whichever Behind the Science photos happen to be on that page.
**After:** Summary reflects all photos consistently.

### Changes

- Add `@all_photos` (unpaginated) in PhotosController#index
- Pass `@all_photos` to sidebar keyword/member/organisation partials
- Add fragment caching on sidebar metadata summary and location map, keyed on `Photo.maximum(:updated_at)`

Fixes #102

## Test plan

- [x] `rails test` — 213 tests, 0 failures
- [x] `/photos` sidebar shows consistent summary across all pages
- [x] Navigate between pages — summary stays the same
- [x] Upload/edit a photo — cache invalidates, summary updates