### PR TITLE
Clean line breaks from Abstract/Contents on save (fixes #139)

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -95,6 +95,7 @@ class Publication < ApplicationRecord
 
   # callbacks
   before_save :create_journal_from_name
+  before_save :clean_line_breaks
 
   # other
   scope :validated, -> {
@@ -497,6 +498,21 @@ class Publication < ApplicationRecord
   # instance methods
   def create_journal_from_name
     create_journal(name: new_journal_name) unless new_journal_name.blank?
+  end
+
+  def clean_line_breaks
+    %i[abstract contents].each do |field|
+      next unless self[field].present?
+      text = self[field]
+      text = text.gsub("\r\n", "\n")        # normalise Windows line endings
+      text = text.gsub("\r", "\n")           # normalise old Mac line endings
+      text = text.gsub(/\n\n+/, "\u0000")   # preserve paragraph breaks (2+ newlines)
+      text = text.gsub("\n", " ")            # replace single newlines with space
+      text = text.gsub("\u0000", "\n\n")     # restore paragraph breaks
+      text = text.squeeze(" ")               # collapse multiple spaces
+      text = text.strip                      # trim leading/trailing whitespace
+      self[field] = text
+    end
   end
 
   def generate_filename_from_doi

--- a/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
+++ b/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
@@ -68,7 +68,7 @@
 | # | Description | Status |
 |---|-------------|--------|
 | 1 | Singular "sponge" not linked in abstracts ([#154][]) | Done |
-| 2 | Line breaks in Abstract/Contents not stripped ([#139][]) | Todo |
+| 2 | Line breaks in Abstract/Contents not stripped ([#139][]) | Done |
 | 3 | Photos metadata summary shows per-page only ([#102][]) | Done |
 | 4 | Behind the Science post format broken ([#98][]) | Todo |
 | 5 | Abstracts missing from some full texts ([#138][]) | Data task |

--- a/test/models/publication_test.rb
+++ b/test/models/publication_test.rb
@@ -119,6 +119,66 @@ class PublicationTest < ActiveSupport::TestCase
     assert_not_includes results, publications(:stats_ecology_redsea)
   end
 
+  # -- Line break cleaning --
+
+  test "clean_line_breaks replaces single newlines with spaces" do
+    pub = publications(:scientific_article)
+    pub.abstract = "Thirty\nnew\nrecords\nof\nfishes"
+    pub.save!
+    assert_equal "Thirty new records of fishes", pub.abstract
+  end
+
+  test "clean_line_breaks preserves double newlines as paragraph breaks" do
+    pub = publications(:scientific_article)
+    pub.abstract = "First paragraph.\n\nSecond paragraph."
+    pub.save!
+    assert_equal "First paragraph.\n\nSecond paragraph.", pub.abstract
+  end
+
+  test "clean_line_breaks handles Windows line endings" do
+    pub = publications(:scientific_article)
+    pub.abstract = "Thirty\r\nnew\r\nrecords"
+    pub.save!
+    assert_equal "Thirty new records", pub.abstract
+  end
+
+  test "clean_line_breaks handles Windows double line endings as paragraph breaks" do
+    pub = publications(:scientific_article)
+    pub.abstract = "First paragraph.\r\n\r\nSecond paragraph."
+    pub.save!
+    assert_equal "First paragraph.\n\nSecond paragraph.", pub.abstract
+  end
+
+  test "clean_line_breaks collapses multiple spaces" do
+    pub = publications(:scientific_article)
+    pub.abstract = "word   word"
+    pub.save!
+    assert_equal "word word", pub.abstract
+  end
+
+  test "clean_line_breaks strips leading and trailing whitespace" do
+    pub = publications(:scientific_article)
+    pub.abstract = "  some text  \n"
+    pub.save!
+    assert_equal "some text", pub.abstract
+  end
+
+  test "clean_line_breaks handles nil fields" do
+    pub = publications(:scientific_article)
+    pub.abstract = nil
+    pub.contents = nil
+    pub.save!
+    assert_nil pub.abstract
+    assert_nil pub.contents
+  end
+
+  test "clean_line_breaks cleans contents field too" do
+    pub = publications(:scientific_article)
+    pub.contents = "INTRODUCTION\r\nOne  of  the\r\nmost  important"
+    pub.save!
+    assert_equal "INTRODUCTION One of the most important", pub.contents
+  end
+
   # -- Task 4: Validation and association tests --
 
   test "requires title" do


### PR DESCRIPTION
## Summary

Add a `before_save` callback on Publication that cleans PDF copy-paste line break artefacts from abstract and contents fields. Preserves intentional paragraph breaks (double newlines).

### What it does

- `\r\n` and `\r` → `\n` (normalise line endings)
- `\n\n+` → preserved as paragraph breaks
- Single `\n` → space (PDF column-wrap artefacts)
- Multiple spaces → single space
- Leading/trailing whitespace stripped

### What it doesn't do

- Does not retroactively clean existing data — only runs on next save
- Does not remove intentional paragraph breaks (double newlines preserved)

Fixes #139

## Test plan

### 1. Run test suite

```sh
rails test
```

**Expected:** 221 tests, 466 assertions, 0 failures

### 2. Verify line break cleaning in console

```sh
rails runner '
ActiveRecord::Base.transaction do
  pub = Publication.joins(:contributor).first
  original = pub.abstract
  pub.abstract = "Thirty\r\nnew\r\nrecords\r\nof\r\nfishes"
  pub.save!
  puts pub.abstract
  raise ActiveRecord::Rollback
end
'
```

**Expected:** `Thirty new records of fishes` (record is rolled back, no data changed)

### 3. Verify paragraph breaks preserved

```sh
rails runner '
ActiveRecord::Base.transaction do
  pub = Publication.joins(:contributor).first
  pub.abstract = "First paragraph.\r\n\r\nSecond paragraph."
  pub.save!
  puts pub.abstract.inspect
  raise ActiveRecord::Rollback
end
'
```

**Expected:** `"First paragraph.\n\nSecond paragraph."` (record is rolled back, no data changed)

### 4. Manual check after deploy

- [x] Edit a publication (with a contributor, e.g. /publications/907/edit), paste text with line breaks from a PDF, save → line breaks cleaned
- [x] Edit a publication with existing clean text, save → no changes to text

### Verified locally

- [x] Step 1: 221 tests pass (8 new tests for line break cleaning)
- [x] Step 2: `Thirty new records of fishes` ✓
- [x] Step 3: `"First paragraph.\n\nSecond paragraph."` ✓