### PR TITLE
Make publication contributor optional (fixes #211)

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -82,7 +82,7 @@ class Publication < ApplicationRecord
   has_many :observations, as: :observable
   has_many :photos
   has_one :featured_post, class_name: 'Post', primary_key: 'id', foreign_key: 'featured_publication_id'
-  belongs_to :contributor, class_name: 'User'
+  belongs_to :contributor, class_name: 'User', optional: true
   has_one_attached :pdf
 
   paginates_per 20

--- a/test/controllers/publications_controller_test.rb
+++ b/test/controllers/publications_controller_test.rb
@@ -60,6 +60,24 @@ class PublicationsControllerIntegrationTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "create sets contributor to current user" do
+    sign_in users(:editor_user)
+    post publications_path, params: {
+      publication: { title: "Contributor Test", authors: "Author A", publication_year: 2021 }
+    }
+    pub = Publication.find_by(title: "Contributor Test")
+    assert_equal users(:editor_user), pub.contributor
+  end
+
+  test "update succeeds for publication without contributor" do
+    sign_in users(:editor_user)
+    pub = publications(:one) # has no contributor
+    patch publication_path(pub), params: {
+      publication: { title: "Updated Title" }
+    }
+    assert_equal "Updated Title", pub.reload.title
+  end
+
   test "destroy redirects unauthenticated user" do
     delete publication_path(publications(:scientific_article))
     assert_redirected_to new_user_session_path

--- a/test/models/publication_test.rb
+++ b/test/models/publication_test.rb
@@ -149,6 +149,15 @@ class PublicationTest < ActiveSupport::TestCase
     assert pub.valid?
   end
 
+  test "publication without contributor is valid" do
+    pub = Publication.new(
+      title: "Legacy Publication",
+      authors: "Author B",
+      publication_year: 2015
+    )
+    assert pub.valid?
+  end
+
   test "belongs to journal" do
     pub = publications(:scientific_article)
     assert_equal journals(:open_journal), pub.journal


### PR DESCRIPTION
## Summary

852 of 1527 publications have no contributor (pre-dates the feature). Rails 5+ enforces `belongs_to` presence by default, so any edit to these publications fails with "Contributor must exist".

One-line fix: add `optional: true` to `belongs_to :contributor`.

Fixes #211

## Test plan

### 1. Run test suite

```sh
rails test
```

**Expected:** 216 tests, 460 assertions, 0 failures

### 2. Verify old publications can be saved

```sh
rails runner '
ActiveRecord::Base.transaction do
  pub = Publication.where(contributor_id: nil).first
  pub.title = pub.title + " (test)"
  puts "Valid: #{pub.valid?}"
  puts "Saves: #{pub.save}"
  raise ActiveRecord::Rollback
end
'
```

**Expected:** `Valid: true`, `Saves: true` (rolled back, no data changed)

### 3. Verify new publications still get contributor

```sh
rails runner '
ActiveRecord::Base.transaction do
  user = User.where(role: "editor").first
  pub = Publication.new(title: "Test", authors: "A", publication_year: 2024)
  pub.contributor = user
  pub.save!
  puts "Contributor: #{pub.contributor.email}"
  raise ActiveRecord::Rollback
end
'
```

**Expected:** Prints the editor's email (rolled back, no data changed)

### Verified locally

- [x] Step 1: 216 tests pass (3 new)
- [x] Step 2: Old publications save successfully
- [x] Step 3: New publications get contributor assigned