### PR TITLE
Add search word occurrences to CSV export (fixes #146)

### DIFF
--- a/app/controllers/publications_controller.rb
+++ b/app/controllers/publications_controller.rb
@@ -51,9 +51,10 @@ class PublicationsController < ApplicationController
 
       format.csv {
         authenticate_user!
-        headers["Content-Disposition"] = "attachment; filename=\"publications.csv\""
+        filename = params[:search].present? ? "publications_search_#{params[:search].parameterize}.csv" : "publications.csv"
+        headers["Content-Disposition"] = "attachment; filename=\"#{filename}\""
         headers["Content-Type"] = "text/csv"
-        self.response_body = Publication.csv_enumerator(@publications.reorder(:id))
+        self.response_body = Publication.csv_enumerator(@publications.reorder(:id), search_term: params[:search])
       }
     end
   end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -329,45 +329,58 @@ class Publication < ApplicationRecord
     [validated, fields, focusgroups, platforms, locations]
   end
 
-  def self.csv_enumerator(scope)
+  def self.csv_enumerator(scope, search_term: nil)
+    has_relevance = search_term.present? && scope.to_sql.include?("scored")
     Enumerator.new do |yielder|
-      yielder << CSV.generate_line(csv_header)
+      if has_relevance
+        yielder << "# Search term: #{search_term}\n"
+      end
+      header = csv_header
+      header.insert(1, "occurrences") if has_relevance
+      yielder << CSV.generate_line(header)
       validated, fields, focusgroups, platforms, locations = csv_association_data
-      scope.csv_rows.find_each(batch_size: 100) do |publication|
-        yielder << CSV.generate_line(csv_row(publication, validated, fields, focusgroups, platforms, locations))
+      rows = has_relevance ? scope.csv_rows_with_relevance : scope.csv_rows
+      rows.find_each(batch_size: 100) do |publication|
+        row = csv_row(publication, validated, fields, focusgroups, platforms, locations)
+        row.insert(1, publication.relevance.to_i) if has_relevance
+        yielder << CSV.generate_line(row)
       end
     end
   end
 
-  scope :csv_rows, -> {
-    select(
-      """
-      publications.id,
+  CSV_ROW_COLUMNS = """
+    publications.id,
+    publications.publication_type,
+    publications.publication_format,
+    publications.publication_year,
+    publications.authors,
+    publications.title,
+    journals.name AS journal_name,
+    publications.volume,
+    publications.issue,
+    publications.pages,
+    publications.DOI,
+    publications.url,
+    publications.book_title,
+    publications.book_authors,
+    publications.book_publisher,
+    active_storage_attachments.id AS pdf_id,
+    publications.mesophotic,
+    publications.mce,
+    publications.tme,
+    publications.original_data,
+    publications.new_species,
+    publications.min_depth,
+    publications.max_depth
+  """.freeze
 
-      publications.publication_type,
-      publications.publication_format,
-      publications.publication_year,
-      publications.authors,
-      publications.title,
-      journals.name AS journal_name,
-      publications.volume,
-      publications.issue,
-      publications.pages,
-      publications.DOI,
-      publications.url,
-      publications.book_title,
-      publications.book_authors,
-      publications.book_publisher,
-      active_storage_attachments.id AS pdf_id,
-      publications.mesophotic,
-      publications.mce,
-      publications.tme,
-      publications.original_data,
-      publications.new_species,
-      publications.min_depth,
-      publications.max_depth
-      """
-    )
+  scope :csv_rows, -> {
+    select(CSV_ROW_COLUMNS)
+    .left_joins(:journal, :pdf_attachment)
+  }
+
+  scope :csv_rows_with_relevance, -> {
+    select("#{CSV_ROW_COLUMNS}, scored.relevance")
     .left_joins(:journal, :pdf_attachment)
   }
 

--- a/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
+++ b/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
@@ -58,7 +58,7 @@
 | 5 | User role consolidation | Done |
 | 6 | Breadcrumb navigation | Done |
 | 7 | EEZ table + location mapping ([#153][]) | Todo |
-| 8 | CSV export: search word count column ([#146][]) | Todo |
+| 8 | CSV export: search word count column ([#146][]) | Done |
 | 9 | Location search autocomplete ([#59][]) | Todo |
 | 10 | Combined newsfeed on home page ([#39][]) | Todo |
 | 11 | Media gallery for CC-licensed photos ([#38][]) | Todo |
@@ -73,6 +73,8 @@
 | 4 | Behind the Science post format broken ([#98][]) | Todo |
 | 5 | Abstracts missing from some full texts ([#138][]) | Data task |
 | 6 | Journal full names missing for new entries ([#136][]) | Data task |
+| 7 | Can't save old publications — contributor validation ([#211][]) | Done |
+| 8 | Suspected duplicate journal entries ([#209][]) | Todo |
 
 ## Infrastructure
 
@@ -226,3 +228,5 @@ These are noted for future planning but not part of this effort:
 [#146]: https://github.com/pimbongaerts/mesophotic/issues/146
 [#153]: https://github.com/pimbongaerts/mesophotic/issues/153
 [#154]: https://github.com/pimbongaerts/mesophotic/issues/154
+[#209]: https://github.com/pimbongaerts/mesophotic/issues/209
+[#211]: https://github.com/pimbongaerts/mesophotic/issues/211

--- a/test/controllers/publications_controller_test.rb
+++ b/test/controllers/publications_controller_test.rb
@@ -101,6 +101,31 @@ class PublicationsControllerIntegrationTest < ActionDispatch::IntegrationTest
     get publications_path(format: :csv)
     assert_response :success
   end
+
+  test "CSV without search has no occurrences column" do
+    sign_in users(:regular_user)
+    get publications_path(format: :csv)
+    lines = response.body.lines
+    header = lines.first
+    assert_not_includes header, "occurrences"
+    assert_no_match(/# Search term:/, response.body)
+  end
+
+  test "CSV with search includes occurrences column and search term comment" do
+    sign_in users(:regular_user)
+    get publications_path(format: :csv, search: "mesophotic")
+    lines = response.body.lines
+    assert_match(/# Search term: mesophotic/, lines.first)
+    header = lines.second
+    assert_includes header, "occurrences"
+  end
+
+  test "CSV with search for editor does not include occurrences" do
+    sign_in users(:editor_user)
+    get publications_path(format: :csv, search: "mesophotic")
+    assert_not_includes response.body, "occurrences"
+    assert_no_match(/# Search term:/, response.body)
+  end
 end
 
 class PublicationsControllerTest < ActionController::TestCase


### PR DESCRIPTION
## Summary

When a regular user searches publications and exports CSV, the occurrence count for the search term is now included as an "occurrences" column. The search term is shown as a comment line above the header.

Editor/admin users use a different search scope that doesn't calculate occurrence counts, so their CSV exports are unchanged.

### Example output

```csv
# Search term: mesophotic
id,validated,...,occurrences
42,true,...,15
```

Fixes #146

## Test plan

- [x] Run `rails test` — 227 tests, 481 assertions, 0 failures
- [x] Export CSV without search (as regular user) — no "occurrences" column, no comment line
- [x] Export CSV with search (as regular user) — first line is `# Search term: mesophotic`, header includes "occurrences", each row has a count
- [x] Export CSV with search (as editor) — normal CSV without occurrences column
- [x] Steps 2-4 also covered by automated tests