### PR TITLE
Fix switch_user widget blocked by CSP

### DIFF
--- a/app/views/switch_user/_widget.html.erb
+++ b/app/views/switch_user/_widget.html.erb
@@ -1,0 +1,4 @@
+<%= form_tag switch_user_path, method: :get, class: "d-inline-flex align-items-center gap-2" do %>
+  <%= select_tag "scope_identifier", option_tags, class: classes, style: styles %>
+  <%= submit_tag "Switch", class: "btn btn-sm btn-outline-secondary" %>
+<% end %>


### PR DESCRIPTION
## Summary

The switch_user gem's default widget uses an inline `onchange` JavaScript handler which CSP blocks. Override the widget partial to use a form with a "Switch" submit button instead.

## Test plan

- [x] Go to `/admin` as an admin user
- [x] Select a different user from the dropdown
- [x] Click "Switch" button
- [ ] Should redirect to home page as the selected user
- [x] Switch back to admin user