### PR TITLE
Normalise post line endings and update template splits

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -27,7 +27,7 @@ class Post < ApplicationRecord
   # associations
   belongs_to :postable, polymorphic: true, optional: true
   belongs_to :user, touch: true
-  belongs_to :featured_user, class_name: 'User', foreign_key: 'featured_user_id'
+  belongs_to :featured_user, class_name: 'User', foreign_key: 'featured_user_id', optional: true
   belongs_to :featured_publication, class_name: 'Publication', foreign_key: 'featured_publication_id', optional: true
   has_many :photos
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -42,7 +42,15 @@ class Post < ApplicationRecord
   validates :content_md, presence: true
 
   # callbacks
-  before_save {
+  before_save :normalise_line_endings
+  before_save :render_markdown
+
+  def normalise_line_endings
+    return unless content_md.present?
+    self.content_md = content_md.gsub("\r\n", "\n").gsub("\r", "\n")
+  end
+
+  def render_markdown
     renderer = Redcarpet::Render::HTML.new(
       filter_html: false,
       no_styles: true,
@@ -53,7 +61,7 @@ class Post < ApplicationRecord
 
     converter = Redcarpet::Markdown.new(renderer)
     self.content_html = converter.render(self.content_md)
-  }
+  end
 
   # other
   extend FriendlyId

--- a/app/views/pages/_post_announcement.html.erb
+++ b/app/views/pages/_post_announcement.html.erb
@@ -50,7 +50,7 @@
 
   <div class="col-sm-9">
     <% if @post.content_md? %>
-      <% behind_sections = @post.content_md.split("\r\n\r\n") %>
+      <% behind_sections = @post.content_md.split("\n\n") %>
       <div class="row">
         <div class="col-sm-12">
           <font color="#2b82bc">

--- a/app/views/pages/_post_behind.html.erb
+++ b/app/views/pages/_post_behind.html.erb
@@ -72,7 +72,7 @@
             <h1>&ldquo;<%= @post.title %>&rdquo;</h1>
           </font><br>
 
-          <% @post.content_md.split(/\s*?\r\n\s*?\r\n\s*?/).zip(@post.photos).in_groups_of(2).each do |bs| %>
+          <% @post.content_md.split("\n\n").zip(@post.photos).in_groups_of(2).each do |bs| %>
             <%= markdown(bs[0][0]) if bs[0].present? %>
             <%= markdown(bs[1][0]) if bs[1].present? %>
             <div class="card">

--- a/app/views/pages/_post_ecr.html.erb
+++ b/app/views/pages/_post_ecr.html.erb
@@ -73,7 +73,7 @@
 
   <div class="col-sm-9">
     <% if @post.content_md? and @post.photos.count > 0 %>
-      <% behind_sections = @post.content_md.split("\r\n\r\n") %>
+      <% behind_sections = @post.content_md.split("\n\n") %>
       <div class="row">
         <div class="col-sm-12">
           <font color="#2b82bc">

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -89,6 +89,27 @@ class PostTest < ActiveSupport::TestCase
     assert post.errors[:featured_user_id].any? || post.errors[:featured_user].any?
   end
 
+  test "post without featured_user is valid for behind_the_science" do
+    post = Post.new(
+      title: "No Featured User BTS",
+      content_md: "Content",
+      post_type: "behind_the_science",
+      user: users(:admin_user),
+      featured_publication: publications(:scientific_article)
+    )
+    assert post.valid?
+  end
+
+  test "post without featured_user is valid for announcement" do
+    post = Post.new(
+      title: "No Featured User Announcement",
+      content_md: "Content",
+      post_type: "announcement",
+      user: users(:admin_user)
+    )
+    assert post.valid?
+  end
+
   test "generates slug from title" do
     post = Post.new(
       title: "A New Unique Post Title",

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -110,6 +110,54 @@ class PostTest < ActiveSupport::TestCase
     assert post.valid?
   end
 
+  # -- Line ending normalisation --
+
+  test "normalises Windows line endings on save" do
+    post = Post.new(
+      title: "Windows Line Endings",
+      content_md: "Section one\r\n\r\nSection two\r\n\r\nSection three",
+      post_type: "announcement",
+      user: users(:admin_user)
+    )
+    post.save!
+    assert_equal "Section one\n\nSection two\n\nSection three", post.content_md
+    assert_not_includes post.content_md, "\r"
+  end
+
+  test "normalises old Mac line endings on save" do
+    post = Post.new(
+      title: "Mac Line Endings",
+      content_md: "Section one\r\rSection two",
+      post_type: "announcement",
+      user: users(:admin_user)
+    )
+    post.save!
+    assert_not_includes post.content_md, "\r"
+  end
+
+  test "preserves Unix line endings on save" do
+    post = Post.new(
+      title: "Unix Line Endings",
+      content_md: "Section one\n\nSection two",
+      post_type: "announcement",
+      user: users(:admin_user)
+    )
+    post.save!
+    assert_equal "Section one\n\nSection two", post.content_md
+  end
+
+  test "normalisation runs before markdown rendering" do
+    post = Post.new(
+      title: "Render After Normalise",
+      content_md: "**bold**\r\n\r\n*italic*",
+      post_type: "announcement",
+      user: users(:admin_user)
+    )
+    post.save!
+    assert_match "<strong>bold</strong>", post.content_html
+    assert_match "<em>italic</em>", post.content_html
+  end
+
   test "generates slug from title" do
     post = Post.new(
       title: "A New Unique Post Title",


### PR DESCRIPTION
## Summary

- Make `featured_user` optional — 6 posts (4 Behind the Science, 2 Announcements) have no featured user. The conditional validation still enforces it for Early Career posts.
- Add `before_save` callback on Post to normalise `\r\n` and `\r` to `\n` in `content_md`
- Update all three post templates to split on `"\n\n"` instead of `"\r\n\r\n"`

Prerequisite for the post type refactor (#98).

**Important:** After deploying, existing posts must be normalised before the template splits take effect.

## Test plan

- [x] Run `rails test` — 233 tests, 493 assertions, 0 failures

- [x] After deploy, normalise existing posts:

```sh
RAILS_ENV=production rails runner '
count = 0
errors = 0
Post.find_each do |post|
  next unless post.content_md.to_s.match?(/\r/)
  if post.save
    count += 1
    print "."
    STDOUT.flush
  else
    errors += 1
    puts "Failed ID #{post.id}: #{post.errors.full_messages.join(", ")}"
  end
end
puts ""
puts "Normalised #{count} posts. #{errors} failures."
'
```

**Expected:** 0 failures

- [x] Verify normalisation:

```sh
RAILS_ENV=production rails runner '
broken = Post.all.count { |p| p.content_md.to_s.include?(13.chr) }
puts broken.to_s + " posts still have carriage returns"
'
```

**Expected:** `0 posts still have carriage returns`

- [x] View a Behind the Science post (e.g. /posts/1) — sections and photos render correctly
- [x] View an Early Career post (e.g. /posts/11) — sections and photos render correctly
- [x] View an Announcement post — content renders correctly