### PR TITLE
Unify post templates with parsed_content rendering (fixes #98)

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -35,9 +35,9 @@ class Post < ApplicationRecord
   validates :post_type, presence: true
   validates :user_id, presence: true
   validates :featured_publication_id, presence: true,
-            :if => lambda { self.post_type == 'behind_the_science'}
+            :if => lambda { post_type.in?(%w[behind_the_science method_feature]) }
   validates :featured_user_id, presence: true,
-            :if => lambda { self.post_type == 'early_career'}
+            :if => lambda { post_type.in?(%w[early_career method_feature]) }
   validates :title, presence: true, length: { maximum: 100 }, uniqueness: true
   validates :content_md, presence: true
 
@@ -90,14 +90,35 @@ class Post < ApplicationRecord
   # class methods
   # instance methods
   def category
-    if post_type == 'behind_the_science'
-      "Behind the Science"
-    elsif post_type == 'early_career'
-      "Early Career Scientist"
-    elsif post_type == 'method_feature'
-      "Methods Exposed"
-    elsif post_type == 'announcement'
-      "Announcement"
+    case post_type
+    when 'behind_the_science' then "Behind the Science"
+    when 'early_career' then "Early Career Scientist"
+    when 'method_feature' then "Methods Exposed"
+    when 'announcement' then "Announcement"
     end
+  end
+
+  # Parse content_md into an ordered array of content blocks.
+  # Sections starting with ##### are "quick questions" — grouped consecutively.
+  # Everything else is a normal section that gets paired with photos.
+  def parsed_content
+    return [] unless content_md.present?
+
+    raw_sections = content_md.split("\n\n").reject(&:blank?)
+    blocks = []
+
+    raw_sections.each do |section|
+      if section.start_with?("#####")
+        if blocks.last && blocks.last[:type] == :quick_question_group
+          blocks.last[:questions] << section
+        else
+          blocks << { type: :quick_question_group, questions: [section] }
+        end
+      else
+        blocks << { type: :section, content: section }
+      end
+    end
+
+    blocks
   end
 end

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -8,53 +8,93 @@
 
 <%= form_for [:admin, @post], role: "form" do |f| %>
 
-<div class="mb-3">
-  <%= f.label :post_type, "Post Type", class: "required" %><br>
-  <%= f.select :post_type, Post::POST_TYPES.map { |t| [t.titleize, t] },
-               {}, class: "form-select" %>
-</div>
+<div class="row">
+  <div class="col-sm-8">
 
-<div class="mb-3">
-  <%= f.label :title, "Title" %>
-  <%= f.text_field :title, autofocus: true, class: "form-control", placeholder: "Title (also used for URL slug)..." %>
-</div>
+    <div class="card mb-3">
+      <div class="card-header"><strong>Post Details</strong></div>
+      <div class="card-body">
+        <div class="mb-3">
+          <%= f.label :post_type, "Type", class: "required" %><br>
+          <%= f.select :post_type, Post::POST_TYPES.map { |t| [t.titleize, t] },
+                       {}, class: "form-select" %>
+        </div>
 
-<div class="mb-3">
-  <%= f.label :content_md, "Content (Markdown)" %>
-  <%= f.text_area :content_md, rows: 20, class: "form-control font-monospace", placeholder: "Use #### for section headings, ##### for quick questions..." %>
-</div>
+        <div class="mb-3">
+          <%= f.label :title, "Title" %>
+          <%= f.text_field :title, autofocus: true, class: "form-control", placeholder: "Title (also used for URL slug)..." %>
+        </div>
 
-<div class="mb-3">
-  <%= f.check_box :draft, class: "form-check-input" %>
-  <%= f.label :draft, "Draft", class: "form-check-label" %>
-</div>
+        <div class="mb-3">
+          <%= f.label :content_md, "Content (Markdown)" %>
+          <%= f.text_area :content_md, rows: 20, class: "form-control font-monospace", placeholder: "Use #### for section headings, ##### for quick questions..." %>
+        </div>
 
-<div class="mb-3">
-  <%= f.label :featured_publication_id, "Featured Publication" %><br>
-  <%= f.collection_select :featured_publication_id,
-                          Publication.all.order("authors ASC, publication_year ASC"),
-                          :id, :short_citation_with_title,
-                          { include_blank: "— None —" },
-                          class: "form-select" %>
-</div>
+        <div class="mb-3">
+          <%= f.label :featured_publication_id, "Featured Publication" %><br>
+          <%= f.collection_select :featured_publication_id,
+                                  Publication.all.order("authors ASC, publication_year ASC"),
+                                  :id, :short_citation_with_title,
+                                  { include_blank: "— None —" },
+                                  { class: "form-select" } %>
+        </div>
 
-<div class="mb-3">
-  <%= f.label :featured_user_id, "Featured User" %><br>
-  <%= f.collection_select :featured_user_id,
-                          User.all.order("last_name ASC, first_name ASC"),
-                          :id, :full_name,
-                          { include_blank: "— None —" },
-                          class: "form-select" %>
-</div>
+        <div class="mb-3">
+          <%= f.label :featured_user_id, "Featured User" %><br>
+          <%= f.collection_select :featured_user_id,
+                                  User.all.order("last_name ASC, first_name ASC"),
+                                  :id, :full_name,
+                                  { include_blank: "— None —" },
+                                  { class: "form-select" } %>
+        </div>
+      </div>
+    </div>
 
-<div class="mb-3">
-  <%= f.label :updated_at, "Published Date" %>
-  <%= f.datetime_select :updated_at, {}, class: "form-select d-inline-block w-auto" %>
-</div>
+    <div class="mb-3 d-flex align-items-center gap-3">
+      <%= f.label :updated_at, "Published Date" %>
+      <%= f.datetime_select :updated_at, {}, class: "form-select d-inline-block w-auto" %>
+      <div class="form-check d-inline-flex align-items-center gap-1 mb-0">
+        <%= f.check_box :draft, class: "form-check-input mt-0" %>
+        <%= f.label :draft, class: "form-check-label" do %><strong>Draft</strong><% end %>
+      </div>
+    </div>
 
-<div class="d-flex gap-2">
-  <%= f.submit "Save", class: "btn btn-primary" %>
-  <%= link_to "Cancel", dashboard_admin_posts_path, class: "btn btn-outline-secondary" %>
+    <div class="d-flex gap-2">
+      <%= f.submit "Save Post", class: "btn btn-primary" %>
+      <%= link_to "Cancel", dashboard_admin_posts_path, class: "btn btn-outline-secondary" %>
+    </div>
+
+  </div>
+
+  <div class="col-sm-4">
+    <div class="card">
+      <div class="card-header"><strong>Content Guide</strong></div>
+      <div class="card-body">
+        <small class="text-muted">
+          <p>All post types support both section types. Use any combination in any order.</p>
+          <p><strong>Section types:</strong></p>
+          <p><code>####</code> Normal section<br>
+          Rendered with the interview text. Photos are inserted in pairs after every two sections.</p>
+          <p><code>#####</code> Quick question<br>
+          Short Q&A displayed in a two-column card. Consecutive quick questions are grouped together. Does not consume photos.</p>
+
+          <p class="mt-3"><strong>Post types:</strong></p>
+          <p><strong>Behind the Science</strong><br>
+          Interview about a publication. Requires a featured publication.</p>
+          <p><strong>Early Career Scientist</strong><br>
+          Interview with a researcher. Requires a featured user. Use <code>#####</code> for the opening quick questions.</p>
+          <p><strong>Methods Exposed</strong><br>
+          Feature on a research method. Requires both a featured publication and featured user.</p>
+          <p><strong>Announcement</strong><br>
+          General news. No featured publication or user required.</p>
+
+          <p class="mt-3"><strong>Photos:</strong></p>
+          <p>Photos are linked separately via the photo edit page. They appear in upload order, paired after every two normal sections.</p>
+          <p class="mb-0"><%= link_to "Markdown syntax reference", "https://daringfireball.net/projects/markdown/syntax", target: "_blank", rel: "noopener" %></p>
+        </small>
+      </div>
+    </div>
+  </div>
 </div>
 
 <% end %>

--- a/app/views/admin/posts/_form.html.erb
+++ b/app/views/admin/posts/_form.html.erb
@@ -9,70 +9,52 @@
 <%= form_for [:admin, @post], role: "form" do |f| %>
 
 <div class="mb-3">
-  <%= f.label :post_type, class: "required" %><br>
-  <%= f.select :post_type, Post::POST_TYPES,
-               class: "form-control" %>
+  <%= f.label :post_type, "Post Type", class: "required" %><br>
+  <%= f.select :post_type, Post::POST_TYPES.map { |t| [t.titleize, t] },
+               {}, class: "form-select" %>
 </div>
 
 <div class="mb-3">
-  <%= f.label :title %>
-  <div class="row">
-    <div class="col-12">
-      <%= f.text_field :title, :autofocus => true, class: "form-control monospaced-control", placeholder: "Title (also used for URL slug)..." %>
-    </div>
-  </div>
+  <%= f.label :title, "Title" %>
+  <%= f.text_field :title, autofocus: true, class: "form-control", placeholder: "Title (also used for URL slug)..." %>
 </div>
 
 <div class="mb-3">
-  <%= f.label :content_md, "Content" %>
-  <div class="row">
-    <div class="col-12">
-      <%= f.text_area :content_md, rows: 15, class: "form-control monospaced-control", placeholder: "Post content (Markdown format)..." %>
-    </div>
-  </div>
+  <%= f.label :content_md, "Content (Markdown)" %>
+  <%= f.text_area :content_md, rows: 20, class: "form-control font-monospace", placeholder: "Use #### for section headings, ##### for quick questions..." %>
 </div>
 
 <div class="mb-3">
-  <div class="row">
-    <div class="col-12">
-      <%= f.check_box :draft %> <%= f.label :draft, "draft" %>
-    </div>
-  </div>
+  <%= f.check_box :draft, class: "form-check-input" %>
+  <%= f.label :draft, "Draft", class: "form-check-label" %>
 </div>
 
 <div class="mb-3">
-  <%= f.label :featured_publication %><br>
+  <%= f.label :featured_publication_id, "Featured Publication" %><br>
   <%= f.collection_select :featured_publication_id,
                           Publication.all.order("authors ASC, publication_year ASC"),
                           :id, :short_citation_with_title,
-                          :include_blank => true,
-                          class: "form-control" %>
+                          { include_blank: "— None —" },
+                          class: "form-select" %>
 </div>
 
 <div class="mb-3">
-  <%= f.label :featured_user %><br>
+  <%= f.label :featured_user_id, "Featured User" %><br>
   <%= f.collection_select :featured_user_id,
                           User.all.order("last_name ASC, first_name ASC"),
                           :id, :full_name,
-                          :include_blank => true,
-                          class: "form-control" %>
+                          { include_blank: "— None —" },
+                          class: "form-select" %>
 </div>
 
 <div class="mb-3">
-  <%= f.label :updated_at, "Published date" %>
-  <div class="row">
-    <div class="col-12">
-      <%= f.datetime_select :updated_at, class: "form-control" %>
-    </div>
-  </div>
+  <%= f.label :updated_at, "Published Date" %>
+  <%= f.datetime_select :updated_at, {}, class: "form-select d-inline-block w-auto" %>
 </div>
 
-<div class="row">
-  <div class="col-12 padded">
-    <button class='btn btn-primary'>
-      <i class='bi bi-plus-square'></i> Publish
-    </button> - <%= link_to "Cancel", dashboard_admin_posts_path %>
-  </div>
+<div class="d-flex gap-2">
+  <%= f.submit "Save", class: "btn btn-primary" %>
+  <%= link_to "Cancel", dashboard_admin_posts_path, class: "btn btn-outline-secondary" %>
 </div>
 
 <% end %>

--- a/app/views/admin/posts/edit.html.erb
+++ b/app/views/admin/posts/edit.html.erb
@@ -1,11 +1,5 @@
 <% title("Edit #{@post.title}") %>
 <%= render partial: 'shared/breadcrumbs', locals: { breadcrumbs: [["Admin", admin_root_path], ["Posts", dashboard_admin_posts_path], [@post.title, nil]] } %>
-<h3 class="page-title">Edit Post <small><%= @post.title %></small></h3>
+<h3 class="page-title">Editing "<%= @post.title %>"</h3>
 
 <%= render 'form' %>
-
-<div class="mt-3">
-  <%= link_to admin_post_path(@post), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }, class: "btn btn-sm btn-outline-danger icon-btn" do %>
-    <i class="bi bi-trash"></i><i class="bi bi-trash-fill"></i> Delete Post
-  <% end %>
-</div>

--- a/app/views/pages/_post_content.html.erb
+++ b/app/views/pages/_post_content.html.erb
@@ -11,6 +11,7 @@
   <%= l @post.created_at.to_date, format: :long %> · Posted by <%= link_to "#{@post.user.first_name} #{@post.user.last_name}", member_pages_path(@post.user), style: "text-decoration: none;" %>
   <% if current_user.try(:editor_or_admin?) %>
     <%= link_to edit_admin_post_path(@post.slug), class: "text-muted icon-btn ms-2" do %><i class="bi bi-pencil"></i><i class="bi bi-pencil-fill"></i><% end %>
+    <%= link_to admin_post_path(@post), data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this post?" }, class: "text-danger icon-btn ms-1" do %><i class="bi bi-trash"></i><i class="bi bi-trash-fill"></i><% end %>
   <% end %>
 </p>
 

--- a/app/views/pages/_post_content.html.erb
+++ b/app/views/pages/_post_content.html.erb
@@ -19,10 +19,16 @@
   <div class="col-sm-3">
 
     <%# Featured user card %>
-    <% featured_person = researcher || (@post.post_type == 'announcement' ? @post.user : nil) %>
+    <% if @post.post_type == 'announcement' %>
+      <% featured_person = @post.user %>
+      <% card_title = "Posted By" %>
+    <% else %>
+      <% featured_person = researcher %>
+      <% card_title = "An Interview With" %>
+    <% end %>
     <% if featured_person.present? %>
       <div class="card">
-        <div class="card-header"><strong><%= researcher.present? ? "An Interview With" : "Posted By" %></strong></div>
+        <div class="card-header"><strong><%= card_title %></strong></div>
         <div class="card-body" align="center">
           <% if featured_person.profile_picture.attached? %>
             <div class="rounded-3 d-inline-block" style="width: 200px; height: 200px; background-color: #f0f1f3; overflow: hidden;">
@@ -65,15 +71,15 @@
       </div>
     </div>
 
-    <%# Location map %>
-    <% if publication.present? %>
+    <%# Location map (not for announcements) %>
+    <% if @post.post_type != 'announcement' && publication.present? %>
       <div class="card">
         <div class="card-header"><strong>Study Location</strong></div>
         <div class="card-body" style="min-height: 150px;">
           <%= turbo_frame_tag "world-map-post-#{@post.id}", src: world_map_path(key: "post_#{@post.id}", model: Location, ids: publication.locations.map(&:id).join(','), height: 150, z: 1), loading: :lazy, target: "_top" %>
         </div>
       </div>
-    <% elsif researcher.present? && researcher.publications.count > 0 %>
+    <% elsif @post.post_type != 'announcement' && researcher.present? && researcher.publications.count > 0 %>
       <div class="card">
         <div class="card-header"><strong>Study Locations</strong></div>
         <div class="card-body">
@@ -85,8 +91,8 @@
       </div>
     <% end %>
 
-    <%# Publication metadata %>
-    <% if publication.present? %>
+    <%# Publication metadata (not for announcements) %>
+    <% if @post.post_type != 'announcement' && publication.present? %>
       <div class="card">
         <div class="card-header"><strong>Publication Metadata</strong></div>
         <div class="card-body">
@@ -106,15 +112,21 @@
 
       <div class="row">
         <div class="col-sm-12">
-          <% if publication.present? %>
+          <% if @post.post_type == 'announcement' %>
             <font color="#2b82bc">
               <h1>&ldquo;<%= @post.title %>&rdquo;</h1>
             </font><br>
-          <% elsif researcher.present? %>
-            <font color="#2b82bc">
-              <h1><%= @post.category %>: <%= researcher.full_name_normal %></h1>
-            </font><br>
-          <% end %>
+            <%= markdown(@post.content_md) %>
+          <% else %>
+            <% if publication.present? %>
+              <font color="#2b82bc">
+                <h1>&ldquo;<%= @post.title %>&rdquo;</h1>
+              </font><br>
+            <% elsif researcher.present? %>
+              <font color="#2b82bc">
+                <h1><%= @post.category %>: <%= researcher.full_name_normal %></h1>
+              </font><br>
+            <% end %>
 
           <% blocks.each do |block| %>
             <% if block[:type] == :quick_question_group %>
@@ -157,6 +169,7 @@
                   </div>
                 </div>
               <% end %>
+            <% end %>
             <% end %>
           <% end %>
 

--- a/app/views/pages/_post_content.html.erb
+++ b/app/views/pages/_post_content.html.erb
@@ -1,0 +1,186 @@
+<% researcher = @post.featured_user %>
+<% publication = @post.featured_publication %>
+
+<%= render partial: "layouts/page_title",
+       locals: {
+         title: publication.present? ? publication.title : @post.title,
+         supertitle: @post.category,
+         breadcrumbs: [["News", posts_pages_path], [(publication.present? ? publication.title_truncated : @post.title), nil]]
+       } %>
+<p class="text-muted mb-4" style="font-size: 0.85em;">
+  <%= l @post.created_at.to_date, format: :long %> · Posted by <%= link_to "#{@post.user.first_name} #{@post.user.last_name}", member_pages_path(@post.user), style: "text-decoration: none;" %>
+  <% if current_user.try(:editor_or_admin?) %>
+    <%= link_to edit_admin_post_path(@post.slug), class: "text-muted icon-btn ms-2" do %><i class="bi bi-pencil"></i><i class="bi bi-pencil-fill"></i><% end %>
+  <% end %>
+</p>
+
+<div class="row">
+  <div class="col-sm-3">
+
+    <%# Featured user card %>
+    <% featured_person = researcher || (@post.post_type == 'announcement' ? @post.user : nil) %>
+    <% if featured_person.present? %>
+      <div class="card">
+        <div class="card-header"><strong><%= researcher.present? ? "An Interview With" : "Posted By" %></strong></div>
+        <div class="card-body" align="center">
+          <% if featured_person.profile_picture.attached? %>
+            <div class="rounded-3 d-inline-block" style="width: 200px; height: 200px; background-color: #f0f1f3; overflow: hidden;">
+              <%= link_to member_pages_path(featured_person) do %>
+                <%= image_tag featured_person.profile_picture.variant(resize: "200x200>"),
+                              style: "width: 100%; height: 100%; object-fit: cover;" %>
+              <% end %>
+            </div>
+          <% end %>
+          <strong>
+            <%= link_to "#{featured_person.first_name} #{featured_person.last_name}", member_pages_path(featured_person) %>
+          </strong><br>
+          <small>
+            <% if featured_person.organisation %>
+              <%= featured_person.organisation.name %>&nbsp;
+              (<%= ISO3166::Country[featured_person.organisation.country] %>)<br>
+            <% end %>
+          </small>
+        </div>
+      </div>
+    <% end %>
+
+    <%# Short bio (ECR / Method) %>
+    <% if researcher.present? && researcher.research_interests.present? %>
+      <div class="card">
+        <div class="card-header"><strong>Short Bio</strong></div>
+        <div class="card-body">
+          <small><%= markdown(researcher.research_interests) %></small>
+        </div>
+      </div>
+    <% end %>
+
+    <%# Word cloud %>
+    <div class="card">
+      <div class="card-header"><strong><%= @post.category %> Keywords</strong></div>
+      <div class="card-body">
+        <%= render partial: 'shared/wordcloud',
+                   object: @post.word_cloud(20),
+                   locals: { title: 'post_contents' } %>
+      </div>
+    </div>
+
+    <%# Location map %>
+    <% if publication.present? %>
+      <div class="card">
+        <div class="card-header"><strong>Study Location</strong></div>
+        <div class="card-body" style="min-height: 150px;">
+          <%= turbo_frame_tag "world-map-post-#{@post.id}", src: world_map_path(key: "post_#{@post.id}", model: Location, ids: publication.locations.map(&:id).join(','), height: 150, z: 1), loading: :lazy, target: "_top" %>
+        </div>
+      </div>
+    <% elsif researcher.present? && researcher.publications.count > 0 %>
+      <div class="card">
+        <div class="card-header"><strong>Study Locations</strong></div>
+        <div class="card-body">
+          <% data = count_geographic_occurrences_of_publications_from_user(researcher) %>
+          <%= render partial: 'shared/world_map', locals: { title: 'Locations',
+                                                            data: data,
+                                                            height: 150 } %>
+        </div>
+      </div>
+    <% end %>
+
+    <%# Publication metadata %>
+    <% if publication.present? %>
+      <div class="card">
+        <div class="card-header"><strong>Publication Metadata</strong></div>
+        <div class="card-body">
+          <%= render partial: 'shared/metadata',
+                     locals: { entity: publication } %>
+        </div>
+      </div>
+    <% end %>
+
+  </div>
+
+  <div class="col-sm-9">
+    <% if @post.content_md? %>
+      <% blocks = @post.parsed_content %>
+      <% photos = @post.photos.to_a %>
+      <% section_count = 0 %>
+
+      <div class="row">
+        <div class="col-sm-12">
+          <% if publication.present? %>
+            <font color="#2b82bc">
+              <h1>&ldquo;<%= @post.title %>&rdquo;</h1>
+            </font><br>
+          <% elsif researcher.present? %>
+            <font color="#2b82bc">
+              <h1><%= @post.category %>: <%= researcher.full_name_normal %></h1>
+            </font><br>
+          <% end %>
+
+          <% blocks.each do |block| %>
+            <% if block[:type] == :quick_question_group %>
+              <div class="card">
+                <div class="card-body" align="center" style="background-color: #f5f5f5">
+                  <div class="row">
+                    <% block[:questions].each_slice(2) do |pair| %>
+                      <% if pair.length == 2 %>
+                        <div class="col-sm-6"><%= markdown(pair[0]) %></div>
+                        <div class="col-sm-6"><%= markdown(pair[1]) %></div>
+                      <% else %>
+                        <div class="col-sm-12"><%= markdown(pair[0]) %></div>
+                      <% end %>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
+            <% else %>
+              <% section_count += 1 %>
+              <%= markdown(block[:content]) %>
+
+              <%# Show a photo pair after every 2 normal sections %>
+              <% if section_count.even? && photos.any? %>
+                <div class="card">
+                  <div class="card-body">
+                    <div class="row">
+                      <% photo = photos.shift %>
+                      <% if photo %>
+                        <div class="col-sm-6">
+                          <%= render partial: 'photo_with_subtitle', locals: { photo: photo } %>
+                        </div>
+                      <% end %>
+                      <% photo = photos.shift %>
+                      <% if photo %>
+                        <div class="col-sm-6">
+                          <%= render partial: 'photo_with_subtitle', locals: { photo: photo } %>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            <% end %>
+          <% end %>
+
+          <%# Featured publication link %>
+          <% if publication.present? %>
+            <h4>Featured Article:</h4>
+            <table class="table table-striped">
+              <%= render partial: 'publications/publication',
+                 locals: { publication: publication } %>
+            </table>
+          <% end %>
+        </div>
+      </div>
+    <% elsif @post.photos.count > 0 %>
+      <div class="row">
+        <div class="col-sm-12">
+          <div class="card">
+            <div class="card-header"><strong>Photos</strong></div>
+            <div class="card-body">
+              <%= render partial: 'shared/behind_the_scenes',
+                         locals: { publication: @post, style: 'full' } %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/pages/show_post.html.erb
+++ b/app/views/pages/show_post.html.erb
@@ -1,7 +1,1 @@
-<% if @post.post_type == 'behind_the_science' %>
-	<%= render 'post_behind' %>
-<% elsif @post.post_type == 'early_career' %>
-	<%= render 'post_ecr' %>
-<% elsif @post.post_type == 'announcement' %>
-	<%= render 'post_announcement' %>
-<% end %>
+<%= render 'post_content' %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,6 +54,9 @@ Rails.application.configure do
     Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :photos
     Bullet.add_safelist type: :unused_eager_loading, class_name: "User", association: :photos_users
 
+    # Post.photos.count used in templates triggers counter cache suggestion
+    Bullet.add_safelist type: :counter_cache, class_name: "Post", association: :photos
+
     # About page eager loads organisation/profile_picture for contributor
     # partial, but fixture users don't match the hardcoded contributor
     # names in the template, so the associations appear unused in tests.

--- a/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
+++ b/docs/superpowers/specs/2026-03-25-rails-modernization-design.md
@@ -70,7 +70,7 @@
 | 1 | Singular "sponge" not linked in abstracts ([#154][]) | Done |
 | 2 | Line breaks in Abstract/Contents not stripped ([#139][]) | Done |
 | 3 | Photos metadata summary shows per-page only ([#102][]) | Done |
-| 4 | Behind the Science post format broken ([#98][]) | Todo |
+| 4 | Behind the Science post format broken ([#98][]) | Done |
 | 5 | Abstracts missing from some full texts ([#138][]) | Data task |
 | 6 | Journal full names missing for new entries ([#136][]) | Data task |
 | 7 | Can't save old publications — contributor validation ([#211][]) | Done |

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -39,6 +39,53 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # -- Post type rendering --
+
+  test "behind_the_science post shows An Interview With" do
+    get post_pages_path(posts(:published_post))
+    assert_response :success
+    assert_match /An Interview With/, response.body
+  end
+
+  test "behind_the_science post shows featured publication link" do
+    get post_pages_path(posts(:published_post))
+    assert_match /Featured Article/, response.body
+  end
+
+  test "announcement post shows Posted By" do
+    get post_pages_path(posts(:announcement_post))
+    assert_response :success
+    assert_match /Posted By/, response.body
+    assert_no_match /An Interview With/, response.body
+  end
+
+  test "announcement post shows title in quotes" do
+    get post_pages_path(posts(:announcement_post))
+    assert_match /Collaborative Mesophotic Project/, response.body
+  end
+
+  test "announcement post does not show location map" do
+    get post_pages_path(posts(:announcement_post))
+    assert_no_match /Study Location/, response.body
+  end
+
+  test "announcement post does not show publication metadata" do
+    get post_pages_path(posts(:announcement_post))
+    assert_no_match /Publication Metadata/, response.body
+  end
+
+  test "early_career post shows quick questions in card" do
+    get post_pages_path(posts(:ecr_post))
+    assert_response :success
+    assert_match /Mee-so or meh-so/, response.body
+    assert_match /Charismatic megafauna/, response.body
+  end
+
+  test "early_career post shows An Interview With" do
+    get post_pages_path(posts(:ecr_post))
+    assert_match /An Interview With/, response.body
+  end
+
   test "inside redirects unauthenticated user" do
     get inside_pages_path
     assert_redirected_to new_user_session_path

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -9,6 +9,25 @@ published_post:
   featured_publication: scientific_article
   slug: "behind-the-science-mesophotic-reefs"
 
+announcement_post:
+  title: "Collaborative Mesophotic Project"
+  content_md: "We are launching a new collaborative project to study mesophotic reefs worldwide."
+  content_html: "<p>We are launching a new collaborative project to study mesophotic reefs worldwide.</p>"
+  draft: false
+  post_type: "announcement"
+  user: admin_user
+  slug: "collaborative-mesophotic-project"
+
+ecr_post:
+  title: "Interview with a Researcher"
+  content_md: "##### Mee-so or meh-so?\nDefinitely meh-so\n\n##### Charismatic megafauna or cool critters?\nCool critters\n\n#### What is your research interest?\nMesophotic coral ecosystems\n\n#### Describe your study site\nGreat Barrier Reef"
+  content_html: "<p>Interview content</p>"
+  draft: false
+  post_type: "early_career"
+  user: admin_user
+  featured_user: regular_user
+  slug: "interview-with-a-researcher"
+
 drafted_post:
   title: "Draft Announcement"
   content_md: "This is a draft post."

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -110,6 +110,88 @@ class PostTest < ActiveSupport::TestCase
     assert post.valid?
   end
 
+  # -- method_feature validations --
+
+  test "method_feature requires both featured_publication and featured_user" do
+    post = Post.new(
+      title: "Method Post",
+      content_md: "Content",
+      post_type: "method_feature",
+      user: users(:admin_user)
+    )
+    assert_not post.valid?
+    assert post.errors[:featured_publication_id].any? || post.errors[:featured_publication].any?
+    assert post.errors[:featured_user_id].any? || post.errors[:featured_user].any?
+  end
+
+  test "method_feature is valid with both featured_publication and featured_user" do
+    post = Post.new(
+      title: "Valid Method Post",
+      content_md: "Content",
+      post_type: "method_feature",
+      user: users(:admin_user),
+      featured_user: users(:admin_user),
+      featured_publication: publications(:scientific_article)
+    )
+    assert post.valid?
+  end
+
+  # -- parsed_content --
+
+  test "parsed_content returns empty array for nil content" do
+    post = Post.new(content_md: nil)
+    assert_equal [], post.parsed_content
+  end
+
+  test "parsed_content returns sections for normal headings" do
+    post = Post.new(content_md: "#### Question one\nAnswer\n\n#### Question two\nAnswer")
+    blocks = post.parsed_content
+    assert_equal 2, blocks.length
+    assert_equal :section, blocks[0][:type]
+    assert_equal :section, blocks[1][:type]
+  end
+
+  test "parsed_content groups consecutive quick questions" do
+    post = Post.new(content_md: "##### Q1\nA1\n\n##### Q2\nA2\n\n#### Normal\nAnswer")
+    blocks = post.parsed_content
+    assert_equal 2, blocks.length
+    assert_equal :quick_question_group, blocks[0][:type]
+    assert_equal 2, blocks[0][:questions].length
+    assert_equal :section, blocks[1][:type]
+  end
+
+  test "parsed_content separates non-consecutive quick question groups" do
+    post = Post.new(content_md: "##### Q1\nA1\n\n#### Normal\nAnswer\n\n##### Q2\nA2")
+    blocks = post.parsed_content
+    assert_equal 3, blocks.length
+    assert_equal :quick_question_group, blocks[0][:type]
+    assert_equal 1, blocks[0][:questions].length
+    assert_equal :section, blocks[1][:type]
+    assert_equal :quick_question_group, blocks[2][:type]
+    assert_equal 1, blocks[2][:questions].length
+  end
+
+  test "parsed_content handles all quick questions" do
+    post = Post.new(content_md: "##### Q1\nA1\n\n##### Q2\nA2\n\n##### Q3\nA3")
+    blocks = post.parsed_content
+    assert_equal 1, blocks.length
+    assert_equal :quick_question_group, blocks[0][:type]
+    assert_equal 3, blocks[0][:questions].length
+  end
+
+  test "parsed_content handles all normal sections" do
+    post = Post.new(content_md: "#### S1\nA1\n\n#### S2\nA2")
+    blocks = post.parsed_content
+    assert_equal 2, blocks.length
+    assert blocks.all? { |b| b[:type] == :section }
+  end
+
+  test "parsed_content skips blank sections" do
+    post = Post.new(content_md: "#### S1\nA1\n\n\n\n#### S2\nA2")
+    blocks = post.parsed_content
+    assert_equal 2, blocks.length
+  end
+
   # -- Line ending normalisation --
 
   test "normalises Windows line endings on save" do


### PR DESCRIPTION
## Summary

Replace three separate post templates with one unified template that uses `parsed_content` to render all post types. Adds `#####` quick question support, makes templates flexible, and cleans up the post form.

### Commits

1. **Add parsed_content to Post, update validations** — parser separates `#####` quick questions from normal sections. Method Feature requires both featured_publication and featured_user.
2. **Add unified post template** — one `_post_content` partial handles all post types. Sidebar renders conditionally. Delete button moved to show page.
3. **Update roadmap**
4. **Clean up post form** — two-column layout with content guide, "Save Post" button, title case labels, `form-select` dropdowns, inline date/draft row.
5. **Fix announcement rendering** — announcements show post author with "Posted By", title in quotes, no location map or photo interleaving.

### How it works

- `#####` headings → quick question groups (two-column card, odd one full-width)
- `####` headings (or plain text) → normal sections, paired with photos every 2 sections
- Quick questions never consume photos
- Groups can appear anywhere in the post, not just at the top
- All post types support both section types

Fixes #98

## Test plan

- [x] Run `rails test` — 250 tests, 540 assertions, 0 failures

- [x] After deploy, update ECR posts to use `#####` for quick questions:

```sh
RAILS_ENV=production rails runner '
count = 0
Post.where(post_type: "early_career").find_each do |post|
  sections = post.content_md.split("\n\n")
  next if sections.length < 2
  changed = false
  [0, 1].each do |i|
    if sections[i].start_with?("####") && !sections[i].start_with?("#####")
      sections[i] = "#" + sections[i]
      changed = true
    end
  end
  if changed
    post.content_md = sections.join("\n\n")
    post.save!
    count += 1
    puts "Updated post #{post.id}: #{post.title[0..50]}"
  end
end
puts "Updated #{count} ECR posts."
'
```

- [x] View a Behind the Science post (e.g. /posts/4) — sidebar shows researcher card, sections interleave with photos
- [x] View an Early Career post (e.g. /posts/11) after data migration — quick questions appear in two-column card at top, remaining sections interleave with photos
- [x] View an Announcement post (e.g. /posts/13) — shows "Posted By" (not "An Interview With"), title in quotes, no location map, no photo interleaving
- [x] Create a new post with post_type "method_feature" — requires both featured_publication and featured_user
- [x] Edit a post — two-column form with content guide on right
- [x] Delete button appears on show page next to edit pencil (not on edit page)