### PR TITLE
Add quick-create links to admin dropdown menu

### DIFF
--- a/app/views/layouts/_user_links.html.erb
+++ b/app/views/layouts/_user_links.html.erb
@@ -7,8 +7,14 @@
 	 	<% if user == 'admin' %>
 		  <li><%= link_to "My profile", member_pages_path(current_user.id), class: "dropdown-item" %></li>
 		  <li><%= link_to "Edit profile", edit_user_registration_path, class: "dropdown-item" %></li>
-		  <li><%= link_to "Admin page", admin_root_path, class: "dropdown-item" %></li>
+		  <li><hr class="dropdown-divider"></li>
+		  <li><%= link_to "New Publication", new_publication_path, class: "dropdown-item" %></li>
+		  <li><%= link_to "New Post", new_admin_post_path, class: "dropdown-item" %></li>
+		  <li><%= link_to "New Photo", new_photo_path, class: "dropdown-item" %></li>
+		  <li><hr class="dropdown-divider"></li>
+		  <li><%= link_to "Dashboard", admin_root_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "Database", rails_admin_path, class: "dropdown-item" %></li>
+		  <li><hr class="dropdown-divider"></li>
 		  <li><%= link_to "Sign out", destroy_user_session_path,
 		                              data:{turbo_method: :delete}, class: "dropdown-item" %></li>
 		<% elsif user == 'regular' %>

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -86,6 +86,31 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_match /An Interview With/, response.body
   end
 
+  # -- Admin dropdown menu --
+
+  test "admin user sees quick-create links in navigation" do
+    sign_in users(:admin_user)
+    get root_path
+    assert_match /New Publication/, response.body
+    assert_match /New Post/, response.body
+    assert_match /New Photo/, response.body
+    assert_match /Dashboard/, response.body
+  end
+
+  test "regular user does not see quick-create links" do
+    sign_in users(:regular_user)
+    get root_path
+    assert_no_match /New Publication/, response.body
+    assert_no_match /New Post/, response.body
+    assert_no_match /New Photo/, response.body
+  end
+
+  test "unauthenticated user does not see quick-create links" do
+    get root_path
+    assert_no_match /New Publication/, response.body
+    assert_no_match /New Post/, response.body
+  end
+
   test "inside redirects unauthenticated user" do
     get inside_pages_path
     assert_redirected_to new_user_session_path


### PR DESCRIPTION
## Summary

Add New Publication, New Post, and New Photo links to the admin dropdown menu with dividers for grouping. Rename "Admin page" to "Dashboard".

## Test plan

- [x] Run `rails test` — 253 tests, 558 assertions, 0 failures
- [x] As admin, click the Admin dropdown — shows New Publication, New Post, New Photo links
- [x] Each link navigates to the correct new/create page
- [x] "Dashboard" links to /admin
- [x] "Database" links to /admin/db
- [x] Regular users don't see the new links
- [x] Unauthenticated users don't see the new links