### PR TITLE
Fix and clean up location new/edit forms

### DIFF
--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -108,7 +108,43 @@
     'depth-series': function(el) { seriesChart(el, 'area', { inverted: true, stacking: 'percent', legend: true }); },
     'map': function(el) { mapChart(el, {}); },
     'map-clickable': function(el) { mapChart(el, { nav: true, clickable: true, dataLabels: true, seriesName: 'Locations', tooltipFormat: '{point.name}' }); },
+    'map-preview': function(el) { mapPreview(el); },
   };
+
+  function mapPreview(el) {
+    var latField = document.getElementById(el.dataset.latField);
+    var lonField = document.getElementById(el.dataset.lonField);
+    var nameField = document.getElementById(el.dataset.nameField);
+    var chart = Highcharts.mapChart(el, {
+      title: { text: '' },
+      credits: { enabled: false },
+      legend: { enabled: false },
+      exporting: { enabled: false },
+      chart: { backgroundColor: 'rgba(255, 255, 255, 0)' },
+      mapNavigation: { enabled: true, buttonOptions: { verticalAlign: 'top' } },
+      series: [
+        { name: 'Countries', mapData: Highcharts.maps['custom/world-continents'], color: '#E0E0E0', enableMouseTracking: false },
+        { type: 'mapbubble', name: 'Location', data: [], maxSize: '12%',
+          dataLabels: { enabled: true, format: '{point.name}' } }
+      ]
+    });
+
+    function updateMarker() {
+      var lat = parseFloat(latField.value);
+      var lon = parseFloat(lonField.value);
+      var name = nameField ? nameField.value.trim() : '';
+      var data = [];
+      if (latField.value.trim() !== '' && lonField.value.trim() !== '' && !isNaN(lat) && !isNaN(lon)) {
+        data = [{ lat: lat, lon: lon, z: 1, name: name }];
+      }
+      chart.series[1].setData(data, true);
+    }
+
+    latField.addEventListener('input', updateMarker);
+    lonField.addEventListener('input', updateMarker);
+    if (nameField) nameField.addEventListener('input', updateMarker);
+    updateMarker();
+  }
 
   // --- WordCloud2 ---
 

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -6,7 +6,8 @@ class MapsController < ApplicationController
     return head(:bad_request) unless model_class
 
     cached = Rails.cache.fetch(["world_map", params[:model], params[:ids], params[:z], Publication.maximum(:updated_at).to_i]) do
-      data = model_class.where(id: params[:ids].split(','))
+      ids = params[:ids].to_s.split(',').reject(&:blank?)
+      data = ids.any? ? model_class.where(id: ids) : model_class.none
       render_to_string partial: 'shared/world_map_clickable',
              locals: { title: params[:model].pluralize.titleize,
                        data: get_coordinates(data, params[:z]),

--- a/app/views/layouts/_user_links.html.erb
+++ b/app/views/layouts/_user_links.html.erb
@@ -11,6 +11,7 @@
 		  <li><%= link_to "New Publication", new_publication_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Post", new_admin_post_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Photo", new_photo_path, class: "dropdown-item" %></li>
+		  <li><%= link_to "New Location", new_location_path, class: "dropdown-item" %></li>
 		  <li><hr class="dropdown-divider"></li>
 		  <li><%= link_to "Dashboard", admin_root_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "Database", rails_admin_path, class: "dropdown-item" %></li>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -1,31 +1,42 @@
-<div class="card">
-  <div class="card-header">
-    <h4 class="card-title">Location</h4>
-  </div>
-  <div class="card-body">
-    <div class="row">
-      <div class="col-7">
+<div class="row">
+  <div class="col-6">
+    <div class="card h-100">
+      <div class="card-header">
+        <strong>Details</strong>
+      </div>
+      <div class="card-body pb-0">
         <div class="mb-3">
-          <%= f.label :description %><br>
-          <%= f.text_field :description, style: 'width:90%;' %>
+          <%= f.label :description, class: "required" %><br>
+          <%= f.text_field :description, class: "form-control",required: true, placeholder: "e.g. Australia - Great Barrier Reef" %>
         </div>
         <div class="mb-3">
-          <%= f.label :latitude %><br>
-          <%= f.text_field :latitude, style: 'width:90%;' %>
+          <%= f.label :latitude, class: "required" %><br>
+          <%= f.text_field :latitude, class: "form-control", required: true, placeholder: "e.g. -16.447284" %>
         </div>
         <div class="mb-3">
-          <%= f.label :longitude %><br>
-          <%= f.text_field :longitude, style: 'width:90%;' %>
+          <%= f.label :longitude, class: "required" %><br>
+          <%= f.text_field :longitude, class: "form-control", required: true, placeholder: "e.g. 145.81735" %>
         </div>
         <% if location.publications.count > 0 %>
-          <p class="bg-danger">
-            &nbsp;Note: <%= location.publications.count %>
-            publications are linked to this location
-          </p>
+          <div class="alert alert-warning mb-0 py-2">
+            <strong>Note:</strong> <%= location.publications.count %>
+            <%= "publication".pluralize(location.publications.count) %> linked to this location
+          </div>
         <% end %>
       </div>
-      <div class="col-5" style="min-height: 230px;">
-        <%= turbo_frame_tag "world-map-locations_form", src: world_map_path(key: "locations_form", model: Location, ids: location.id, height: 230), loading: :lazy %>
+    </div>
+  </div>
+  <div class="col-6">
+    <div class="card h-100">
+      <div class="card-header">
+        <strong>Map</strong>
+      </div>
+      <div class="card-body d-flex flex-column p-2">
+        <div data-chart="map-preview"
+             data-lat-field="location_latitude"
+             data-lon-field="location_longitude"
+             data-name-field="location_description"
+             class="flex-grow-1" style="min-height: 200px;"></div>
       </div>
     </div>
   </div>

--- a/app/views/locations/edit.html.erb
+++ b/app/views/locations/edit.html.erb
@@ -1,10 +1,12 @@
 <%= render partial: "layouts/page_title",
-       locals: {title: "Edit location",
-          subtitle: "#{@location.description}",
+       locals: {title: "Editing \"#{@location.description}\"",
           breadcrumbs: [["Locations", locations_path], [@location.description, nil]] } %>
 
 <%= form_for(@location) do |f| %>
   <%= render partial: 'form', locals: {f: f, 
   									   location: @location} %>
-  <div class="actions"><%= f.submit "Save Location", class: "btn btn-primary" %></div>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Location", class: "btn btn-primary" %>
+    <%= link_to "Cancel", locations_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/app/views/locations/new.html.erb
+++ b/app/views/locations/new.html.erb
@@ -1,10 +1,21 @@
 <%= render partial: "layouts/page_title",
-       locals: {title: "New location",
-          subtitle: "",
+       locals: {title: "New Location",
           breadcrumbs: [["Locations", locations_path], ["New", nil]] } %>
 
 <%= form_for(@location) do |f| %>
-  <%= render partial: 'form', locals: {f: f, 
-  									   location: @location} %>
-  <div class="actions"><%= f.submit "Save Location", class: "btn btn-primary" %></div>
+  <% if @location.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@location.errors.count, "error") %> prohibited this location from being saved:</h5>
+      <ul class="mb-0">
+        <% @location.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= render partial: 'form', locals: {f: f, location: @location} %>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Location", class: "btn btn-primary" %>
+    <%= link_to "Cancel", locations_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/db/migrate/20260412022620_change_location_coordinate_defaults_to_null.rb
+++ b/db/migrate/20260412022620_change_location_coordinate_defaults_to_null.rb
@@ -1,0 +1,6 @@
+class ChangeLocationCoordinateDefaultsToNull < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :locations, :latitude, from: 0.0, to: nil
+    change_column_default :locations, :longitude, from: 0.0, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_121530) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_022620) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.integer "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -164,8 +164,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_10_121530) do
   create_table "locations", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "description", limit: 255
-    t.decimal "latitude", precision: 15, scale: 10, default: "0.0"
-    t.decimal "longitude", precision: 15, scale: 10, default: "0.0"
+    t.decimal "latitude", precision: 15, scale: 10
+    t.decimal "longitude", precision: 15, scale: 10
     t.text "short_description"
     t.datetime "updated_at", precision: nil, null: false
   end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -4,6 +4,8 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
   # index requires Active Storage attachments for featured location photo;
   # tested manually. These tests cover auth gates.
 
+  # --- auth gates ---
+
   test "new redirects unauthenticated user" do
     get new_location_path
     assert_redirected_to new_user_session_path
@@ -24,5 +26,124 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     sign_in users(:editor_user)
     get edit_location_path(locations(:great_barrier_reef))
     assert_response :success
+  end
+
+  test "create redirects unauthenticated user" do
+    post locations_path, params: { location: { description: "Test", latitude: 10, longitude: 20 } }
+    assert_redirected_to new_user_session_path
+  end
+
+  # --- new form rendering ---
+
+  test "new form has required field indicators" do
+    sign_in users(:editor_user)
+    get new_location_path
+    assert_select 'label.required', count: 3
+  end
+
+  test "new form has placeholder text" do
+    sign_in users(:editor_user)
+    get new_location_path
+    assert_select 'input[placeholder]', minimum: 3
+  end
+
+  test "new form has map preview element" do
+    sign_in users(:editor_user)
+    get new_location_path
+    assert_select '[data-chart="map-preview"]'
+  end
+
+  test "new form has cancel button" do
+    sign_in users(:editor_user)
+    get new_location_path
+    assert_select 'a[href=?]', locations_path, text: "Cancel"
+  end
+
+  # --- edit form rendering ---
+
+  test "edit form shows location name in title" do
+    sign_in users(:editor_user)
+    loc = locations(:great_barrier_reef)
+    get edit_location_path(loc)
+    assert_match /Editing/, response.body
+    assert_match loc.description, response.body
+  end
+
+  test "edit form has required field indicators" do
+    sign_in users(:editor_user)
+    get edit_location_path(locations(:great_barrier_reef))
+    assert_select 'label.required', count: 3
+  end
+
+  test "edit form has live map preview" do
+    sign_in users(:editor_user)
+    get edit_location_path(locations(:great_barrier_reef))
+    assert_select '[data-chart="map-preview"]'
+  end
+
+  test "edit form has cancel button" do
+    sign_in users(:editor_user)
+    get edit_location_path(locations(:great_barrier_reef))
+    assert_select 'a[href=?]', locations_path, text: "Cancel"
+  end
+
+  # --- create ---
+
+  test "create succeeds for editor with valid params" do
+    sign_in users(:editor_user)
+    assert_difference 'Location.count', 1 do
+      post locations_path, params: { location: { description: "New Reef", latitude: -15.5, longitude: 145.8 } }
+    end
+    assert_redirected_to edit_location_path(Location.last)
+  end
+
+  test "create fails with missing description" do
+    sign_in users(:editor_user)
+    assert_no_difference 'Location.count' do
+      post locations_path, params: { location: { description: "", latitude: -15.5, longitude: 145.8 } }
+    end
+    assert_response :success # re-renders form
+  end
+
+  test "create fails with missing latitude" do
+    sign_in users(:editor_user)
+    assert_no_difference 'Location.count' do
+      post locations_path, params: { location: { description: "Test", latitude: "", longitude: 145.8 } }
+    end
+    assert_response :success
+  end
+
+  test "create fails with missing longitude" do
+    sign_in users(:editor_user)
+    assert_no_difference 'Location.count' do
+      post locations_path, params: { location: { description: "Test", latitude: -15.5, longitude: "" } }
+    end
+    assert_response :success
+  end
+
+  test "create fails with out-of-range latitude" do
+    sign_in users(:editor_user)
+    assert_no_difference 'Location.count' do
+      post locations_path, params: { location: { description: "Test", latitude: 91, longitude: 145.8 } }
+    end
+    assert_response :success
+  end
+
+  # --- update ---
+
+  test "update succeeds for editor" do
+    sign_in users(:editor_user)
+    loc = locations(:great_barrier_reef)
+    patch location_path(loc), params: { location: { description: "Updated Reef" } }
+    assert_redirected_to edit_location_path(loc)
+    assert_equal "Updated Reef", loc.reload.description
+  end
+
+  test "update fails with blank description" do
+    sign_in users(:editor_user)
+    loc = locations(:great_barrier_reef)
+    patch location_path(loc), params: { location: { description: "" } }
+    assert_response :success
+    assert_not_equal "", loc.reload.description
   end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -94,6 +94,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_match /New Publication/, response.body
     assert_match /New Post/, response.body
     assert_match /New Photo/, response.body
+    assert_match /New Location/, response.body
     assert_match /Dashboard/, response.body
   end
 
@@ -103,6 +104,7 @@ class PagesControllerTest < ActionDispatch::IntegrationTest
     assert_no_match /New Publication/, response.body
     assert_no_match /New Post/, response.body
     assert_no_match /New Photo/, response.body
+    assert_no_match /New Location/, response.body
   end
 
   test "unauthenticated user does not see quick-create links" do


### PR DESCRIPTION
## Summary
- Fix crash on new location form (map Turbo Frame received nil ID)
- Harden MapsController to handle missing/blank IDs gracefully
- Replace static Turbo Frame map with live client-side map preview on both new and edit forms
  - Marker updates in real-time as you type lat/lon/description
  - Shows location name as data label on the marker
- Redesign form layout: Details and Map as side-by-side equal-height cards
- Add required field indicators (red asterisks), placeholders, full-width inputs
- Change lat/lon database default from 0.0 to nil — prevents accidental 0,0 saves
- Add page title with breadcrumbs, validation errors, cancel buttons
- Edit title uses `Editing "Location Name"` pattern
- Use `<strong>` card headers and `alert-warning` for publication count
- Add "New Location" to admin dropdown menu
- Add 16 controller tests for form rendering, create, update, and auth gates

## Test plan
- [x] Visit `/locations/new` — empty map renders, no crash
- [x] Fields show placeholders and required asterisks
- [x] Lat/lon fields are empty (not 0.0) on new form
- [x] Type coordinates — marker appears when both fields have values
- [x] Type description — marker label updates live
- [x] Edit existing location — map shows marker at current coordinates with name
- [x] Change coordinates on edit — marker moves in real-time
- [x] Submit with blank fields — validation errors display
- [x] Cancel button returns to locations index
- [x] Admin dropdown includes "New Location" link
- [x] Run `rails test` — all 269 tests pass
