### PR TITLE
Add EEZ (Exclusive Economic Zone) data (fixes #153)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 *.csv
+!/db/seeds/*.csv
 *~
 .byebug_history
 .DS_Store

--- a/app/assets/javascripts/charts.js
+++ b/app/assets/javascripts/charts.js
@@ -109,6 +109,7 @@
     'map': function(el) { mapChart(el, {}); },
     'map-clickable': function(el) { mapChart(el, { nav: true, clickable: true, dataLabels: true, seriesName: 'Locations', tooltipFormat: '{point.name}' }); },
     'map-preview': function(el) { mapPreview(el); },
+    'map-colored': function(el) { mapColored(el); },
   };
 
   function mapPreview(el) {
@@ -144,6 +145,45 @@
     lonField.addEventListener('input', updateMarker);
     if (nameField) nameField.addEventListener('input', updateMarker);
     updateMarker();
+  }
+
+  function mapColored(el) {
+    var data = JSON.parse(el.dataset.values);
+    var config = baseOpts(el);
+    config.chart = { backgroundColor: 'rgba(255, 255, 255, 0)' };
+    config.mapNavigation = { enabled: true, buttonOptions: { verticalAlign: 'top' } };
+    config.exporting = { enabled: false };
+
+    var palette = ['#058DC7', '#50B432', '#ED561B', '#DDDF00', '#24CBE5',
+                   '#64E572', '#FF9655', '#FFF263', '#6AF9C4', '#FF6B6B',
+                   '#C49C94', '#9EDAE5', '#DBDB8D', '#E377C2', '#7F7F7F'];
+    var groups = {};
+    data.forEach(function(point) {
+      if (!groups[point.sovereign]) groups[point.sovereign] = [];
+      groups[point.sovereign].push(point);
+    });
+
+    var series = [
+      { name: 'Countries', mapData: Highcharts.maps['custom/world-continents'], color: '#E0E0E0', enableMouseTracking: false }
+    ];
+
+    var sovereigns = Object.keys(groups).sort();
+    sovereigns.forEach(function(sov, i) {
+      series.push({
+        type: 'mapbubble',
+        name: sov,
+        data: groups[sov],
+        color: palette[i % palette.length],
+        maxSize: '12%',
+        dataLabels: { enabled: true, format: '{point.name}' },
+        cursor: 'pointer',
+        point: { events: { click: function() { if (this.options.url) window.location = this.options.url; } } }
+      });
+    });
+
+    config.legend = { enabled: true };
+    config.series = series;
+    Highcharts.mapChart(el, config);
   }
 
   // --- WordCloud2 ---

--- a/app/assets/javascripts/tom_select_init.js
+++ b/app/assets/javascripts/tom_select_init.js
@@ -8,6 +8,7 @@ function initTomSelectOn(el) {
     create: false,
     allowEmptyOption: true,
     selectOnTab: true,
+    maxOptions: el.dataset.maxOptions ? parseInt(el.dataset.maxOptions) : 1000,
     onFocus: function() {
       this._previousValue = this.getValue();
       this.clear(true);

--- a/app/controllers/eezs_controller.rb
+++ b/app/controllers/eezs_controller.rb
@@ -1,0 +1,25 @@
+class EezsController < ApplicationController
+  def index
+    @studied = Eez.with_publications
+      .select("eezs.*, COUNT(DISTINCT publications.id) AS publications_count")
+      .joins(locations: :publications)
+      .group("eezs.id")
+      .order(:sovereign, :territory)
+      .group_by(&:sovereign)
+
+    @unstudied = Eez.where.not(id: Eez.with_publications)
+      .order(:sovereign, :territory)
+      .group_by(&:sovereign)
+  end
+
+  def show
+    @eez = Eez.find_by(id: params[:id])
+    return head(:not_found) unless @eez
+
+    @locations = @eez.locations
+      .left_joins(:publications)
+      .select("locations.*, COUNT(publications.id) AS publications_count")
+      .group("locations.id")
+      .order(Arel.sql("COUNT(publications.id) DESC"))
+  end
+end

--- a/app/controllers/eezs_controller.rb
+++ b/app/controllers/eezs_controller.rb
@@ -10,6 +10,11 @@ class EezsController < ApplicationController
     @unstudied = Eez.where.not(id: Eez.with_publications)
       .order(:sovereign, :territory)
       .group_by(&:sovereign)
+
+    @map_data = Location.joins(:publications, :eez)
+      .select("locations.*, eezs.sovereign, COUNT(DISTINCT publications.id) AS pub_count")
+      .group("locations.id")
+      .map { |l| { name: l.description, lat: l.latitude.to_f, lon: l.longitude.to_f, z: l.pub_count, sovereign: l.sovereign, url: summary_path(model: "locations", id: l.id) } }
   end
 
   def show

--- a/app/controllers/eezs_controller.rb
+++ b/app/controllers/eezs_controller.rb
@@ -11,6 +11,10 @@ class EezsController < ApplicationController
       .order(:sovereign, :territory)
       .group_by(&:sovereign)
 
+    @location_eez_map = Location.includes(:eez).where.not(eez_id: nil)
+      .order(:description)
+      .map { |l| { description: l.description, eez_path: "#{eez_path(l.eez)}#loc-#{l.id}", territory: l.eez.territory, sovereign: l.eez.sovereign } }
+
     @map_data = Location.joins(:publications, :eez)
       .select("locations.*, eezs.sovereign, COUNT(DISTINCT publications.id) AS pub_count")
       .group("locations.id")

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -65,6 +65,6 @@ class LocationsController < ApplicationController
   end
 
   def location_params
-    params.require(:location).permit(:description, :latitude, :longitude)
+    params.require(:location).permit(:description, :latitude, :longitude, :eez_id)
   end
 end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -6,6 +6,7 @@ class StatsController < ApplicationController
     :growing_authors_over_time,
     :world_publications,
     :world_locations,
+    :world_sovereigns,
     :summarized_fields,
     :summarized_journals,
     :summarized_focusgroups,
@@ -132,6 +133,17 @@ class StatsController < ApplicationController
       .order(Arel.sql('count(locations.id) DESC'))
 
     render_in_turbo_frame("stats-world_locations") { render_to_string partial: "world_locations" }
+  end
+
+  def world_sovereigns
+    @sovereigns = Eez
+      .joins(locations: :publications)
+      .select("eezs.sovereign AS description, eezs.sovereign AS chart_description, COUNT(DISTINCT publications.id) AS publications_count")
+      .where("publications.id IN (SELECT id FROM (#{@publications.to_sql}))")
+      .group("eezs.sovereign")
+      .order(Arel.sql("COUNT(DISTINCT publications.id) DESC"))
+
+    render_in_turbo_frame("stats-world_sovereigns") { render_to_string partial: "world_sovereigns" }
   end
 
   def time_refuge

--- a/app/models/eez.rb
+++ b/app/models/eez.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: eezs
+#
+#  id         :integer          not null, primary key
+#  mrgid      :integer          not null
+#  geoname    :string           not null
+#  sovereign  :string           not null
+#  territory  :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Eez < ApplicationRecord
+  has_many :locations
+  has_many :publications, -> { distinct }, through: :locations
+
+  validates :mrgid, presence: true, uniqueness: true
+  validates :geoname, presence: true
+  validates :sovereign, presence: true
+  validates :territory, presence: true
+
+  scope :by_sovereign, ->(name) { where(sovereign: name) }
+  scope :with_publications, -> {
+    joins(locations: :publications).distinct
+  }
+
+  def self.sovereigns
+    distinct.pluck(:sovereign).sort
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -6,9 +6,10 @@
 #  description       :string(255)
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  latitude          :decimal(15, 10)  default(0.0)
-#  longitude         :decimal(15, 10)  default(0.0)
+#  latitude          :decimal(15, 10)
+#  longitude         :decimal(15, 10)
 #  short_description :text
+#  eez_id            :integer
 #
 
 class Location < ApplicationRecord
@@ -20,6 +21,7 @@ class Location < ApplicationRecord
   has_and_belongs_to_many :expeditions, touch: true
   has_many :sites # TODO: CHECK
   has_many :photos
+  belongs_to :eez, optional: true
 
   # validations
   validates :description, presence: true

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -63,6 +63,14 @@ class Publication < ApplicationRecord
   def self.publication_fields
     @publication_fields ||= Field.select(:description).order(:description).map(&:description).uniq.freeze
   end
+
+  def self.publication_sovereigns
+    Eez.joins(locations: :publications)
+      .distinct
+      .pluck(:sovereign)
+      .sort
+  end
+
   WORDCLOUD_FREQLIMIT = 50.freeze
 
   # attributes
@@ -149,6 +157,7 @@ class Publication < ApplicationRecord
     .focusgroups(search_params["focusgroups"])
     .platforms(search_params["platforms"])
     .fields(search_params["fields"])
+    .by_sovereign(search_params["sovereigns"])
     .where("publication_type IN (?) OR publication_type IS NULL", search_params["types"])
     .where("publication_format IN (?) OR publication_format IS NULL", search_params["formats"])
     .where(((search_params["characteristics"] || []) & publication_characteristics).map { |c| "#{c} = 1" }.join(" OR "))
@@ -167,6 +176,17 @@ class Publication < ApplicationRecord
       end
     }
   end
+
+  scope :by_sovereign, ->(params) {
+    if params.present?
+      joins("INNER JOIN locations_publications ON publications.id = locations_publications.publication_id")
+      .joins("INNER JOIN locations ON locations.id = locations_publications.location_id")
+      .joins("INNER JOIN eezs ON eezs.id = locations.eez_id")
+      .where("eezs.sovereign IN (?)", params)
+    else
+      all
+    end
+  }
 
   scope :sift, -> (search_term, search_params = Publication.default_search_params) {
     if search_term.present?
@@ -461,6 +481,7 @@ class Publication < ApplicationRecord
       "year_range" => "#{min_year},#{max_year}",
       "types" => PUBLICATION_TYPES,
       "formats" => PUBLICATION_FORMATS,
+      "sovereigns" => nil,
       # "characteristics" => [],
       # "locations" => [],
       # "focusgroups" => [],

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -317,9 +317,21 @@ class Publication < ApplicationRecord
         .joins(:publications)
         .group("publications.id")
         .reduce({}) { |result, a| result.update(a.id => a.description) }
+      eez_sovereigns = Location
+        .select("publications.id, GROUP_CONCAT(DISTINCT eezs.sovereign) AS sovereign_names")
+        .joins(:publications)
+        .left_joins(:eez)
+        .group("publications.id")
+        .reduce({}) { |result, a| result.update(a.id => a.sovereign_names) }
+      eez_territories = Location
+        .select("publications.id, GROUP_CONCAT(DISTINCT eezs.territory) AS territory_names")
+        .joins(:publications)
+        .left_joins(:eez)
+        .group("publications.id")
+        .reduce({}) { |result, a| result.update(a.id => a.territory_names) }
 
       for publication in csv_rows
-        csv << csv_row(publication, validated, fields, focusgroups, platforms, locations)
+        csv << csv_row(publication, validated, fields, focusgroups, platforms, locations, eez_sovereigns, eez_territories)
       end
     end
   }
@@ -346,7 +358,19 @@ class Publication < ApplicationRecord
       .joins(:publications)
       .group("publications.id")
       .reduce({}) { |result, a| result.update(a.id => a.description) }
-    [validated, fields, focusgroups, platforms, locations]
+    eez_sovereigns = Location
+      .select("publications.id, GROUP_CONCAT(DISTINCT eezs.sovereign) AS sovereign_names")
+      .joins(:publications)
+      .left_joins(:eez)
+      .group("publications.id")
+      .reduce({}) { |result, a| result.update(a.id => a.sovereign_names) }
+    eez_territories = Location
+      .select("publications.id, GROUP_CONCAT(DISTINCT eezs.territory) AS territory_names")
+      .joins(:publications)
+      .left_joins(:eez)
+      .group("publications.id")
+      .reduce({}) { |result, a| result.update(a.id => a.territory_names) }
+    [validated, fields, focusgroups, platforms, locations, eez_sovereigns, eez_territories]
   end
 
   def self.csv_enumerator(scope, search_term: nil)
@@ -358,10 +382,10 @@ class Publication < ApplicationRecord
       header = csv_header
       header.insert(1, "occurrences") if has_relevance
       yielder << CSV.generate_line(header)
-      validated, fields, focusgroups, platforms, locations = csv_association_data
+      validated, fields, focusgroups, platforms, locations, eez_sovereigns, eez_territories = csv_association_data
       rows = has_relevance ? scope.csv_rows_with_relevance : scope.csv_rows
       rows.find_each(batch_size: 100) do |publication|
-        row = csv_row(publication, validated, fields, focusgroups, platforms, locations)
+        row = csv_row(publication, validated, fields, focusgroups, platforms, locations, eez_sovereigns, eez_territories)
         row.insert(1, publication.relevance.to_i) if has_relevance
         yielder << CSV.generate_line(row)
       end
@@ -434,11 +458,13 @@ class Publication < ApplicationRecord
       "fields",
       "focusgroups",
       "platforms",
-      "locations"
+      "locations",
+      "eez_sovereign",
+      "eez_territory"
     ]
   end
 
-  def self.csv_row publication, validated, fields, focusgroups, platforms, locations
+  def self.csv_row publication, validated, fields, focusgroups, platforms, locations, eez_sovereigns, eez_territories
     isValidated = validated.include?(publication.id)
 
     [
@@ -471,6 +497,8 @@ class Publication < ApplicationRecord
       focusgroups[publication.id],
       platforms[publication.id],
       locations[publication.id],
+      eez_sovereigns[publication.id],
+      eez_territories[publication.id],
     ]
   end
 

--- a/app/views/eezs/index.html.erb
+++ b/app/views/eezs/index.html.erb
@@ -1,0 +1,102 @@
+<%= render partial: "layouts/page_title",
+           locals: {
+             title: "EEZ / Countries",
+             breadcrumbs: [["EEZ / Countries", nil]]
+           } %>
+
+<div class="row">
+  <div class="col-sm-8">
+    <div class="mb-3">
+      <select data-tom-select="navigate" data-placeholder="Search for a country or territory..." class="form-select" style="width: auto; display: inline-block;">
+        <option value="">Search for a country or territory...</option>
+        <% @studied.each do |sovereign, eezs| %>
+          <% eezs.each do |eez| %>
+            <option value="<%= eez_path(eez) %>">
+              <%= eez.sovereign %> &mdash; <%= eez.territory %> (<%= eez.publications_count %> publications)
+            </option>
+          <% end %>
+        <% end %>
+      </select>
+    </div>
+
+    <div class="card mb-3">
+      <div class="card-header">
+        <strong>Studied EEZ / Countries</strong>
+        <span class="text-muted">(<%= @studied.values.flatten.size %> EEZs across <%= @studied.keys.size %> countries)</span>
+      </div>
+      <div class="card-body p-0">
+        <div class="accordion accordion-flush" id="studied-sovereigns">
+          <% @studied.each_with_index do |(sovereign, eezs), index| %>
+            <% sovereign_id = "sovereign-#{sovereign.parameterize}" %>
+            <% total_pubs = eezs.sum { |e| e.publications_count.to_i } %>
+            <div class="accordion-item">
+              <h2 class="accordion-header">
+                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#<%= sovereign_id %>" aria-expanded="false" aria-controls="<%= sovereign_id %>">
+                  <strong><%= sovereign %></strong>
+                  <span class="badge bg-primary ms-2"><%= total_pubs %></span>
+                </button>
+              </h2>
+              <div id="<%= sovereign_id %>" class="accordion-collapse collapse" data-bs-parent="#studied-sovereigns">
+                <div class="accordion-body p-0">
+                  <ul class="list-group list-group-flush">
+                    <% eezs.each do |eez| %>
+                      <li class="list-group-item d-flex justify-content-between align-items-center">
+                        <%= link_to eez.territory, eez_path(eez) %>
+                        <span class="badge bg-secondary rounded-pill"><%= eez.publications_count %></span>
+                      </li>
+                    <% end %>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <% if @unstudied.any? %>
+      <div class="card mb-3">
+        <div class="card-header">
+          <strong>Unstudied EEZ / Countries</strong>
+          <span class="text-muted">(<%= @unstudied.values.flatten.size %> EEZs across <%= @unstudied.keys.size %> countries)</span>
+        </div>
+        <div class="card-body p-0">
+          <div class="accordion accordion-flush" id="unstudied-sovereigns">
+            <% @unstudied.each do |sovereign, eezs| %>
+              <% sovereign_id = "unstudied-#{sovereign.parameterize}" %>
+              <div class="accordion-item">
+                <h2 class="accordion-header">
+                  <button class="accordion-button collapsed text-muted" type="button" data-bs-toggle="collapse" data-bs-target="#<%= sovereign_id %>" aria-expanded="false" aria-controls="<%= sovereign_id %>">
+                    <%= sovereign %>
+                  </button>
+                </h2>
+                <div id="<%= sovereign_id %>" class="accordion-collapse collapse" data-bs-parent="#unstudied-sovereigns">
+                  <div class="accordion-body p-0">
+                    <ul class="list-group list-group-flush">
+                      <% eezs.each do |eez| %>
+                        <li class="list-group-item text-muted">
+                          <%= eez.territory %>
+                        </li>
+                      <% end %>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="col-sm-4">
+    <div class="card">
+      <div class="card-header">
+        <strong>Map</strong>
+      </div>
+      <div class="card-body" style="min-height: 380px; background-color: #f0f1f3;">
+        <p class="text-muted text-center mt-5">Map placeholder</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/eezs/index.html.erb
+++ b/app/views/eezs/index.html.erb
@@ -95,7 +95,9 @@
         <strong>Map</strong>
       </div>
       <div class="card-body" style="min-height: 380px; background-color: #f0f1f3;">
-        <p class="text-muted text-center mt-5">Map placeholder</p>
+        <div data-chart="map-colored"
+             data-values="<%= @map_data.to_json %>"
+             style="height: 400px;"></div>
       </div>
     </div>
   </div>

--- a/app/views/eezs/index.html.erb
+++ b/app/views/eezs/index.html.erb
@@ -7,15 +7,24 @@
 <div class="row">
   <div class="col-sm-8">
     <div class="mb-3">
-      <select data-tom-select="navigate" data-placeholder="Search for a country or territory..." class="form-select" style="width: auto; display: inline-block;">
-        <option value="">Search for a country or territory...</option>
-        <% @studied.each do |sovereign, eezs| %>
-          <% eezs.each do |eez| %>
-            <option value="<%= eez_path(eez) %>">
-              <%= eez.sovereign %> &mdash; <%= eez.territory %> (<%= eez.publications_count %> publications)
+      <select data-tom-select="navigate" data-placeholder="Search for a country, territory, or location..." data-max-options="500" class="form-select" style="width: auto; display: inline-block;">
+        <option value="">Search for a country, territory, or location...</option>
+        <optgroup label="Countries / Territories">
+          <% @studied.each do |sovereign, eezs| %>
+            <% eezs.each do |eez| %>
+              <option value="<%= eez_path(eez) %>">
+                <%= eez.sovereign %> — <%= eez.territory %> (<%= eez.publications_count %> publications)
+              </option>
+            <% end %>
+          <% end %>
+        </optgroup>
+        <optgroup label="Locations">
+          <% @location_eez_map.each do |loc| %>
+            <option value="<%= loc[:eez_path] %>">
+              <%= loc[:description] %> - <%= loc[:territory] %> (<%= loc[:sovereign] %>)
             </option>
           <% end %>
-        <% end %>
+        </optgroup>
       </select>
     </div>
 
@@ -32,8 +41,10 @@
             <div class="accordion-item">
               <h2 class="accordion-header">
                 <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#<%= sovereign_id %>" aria-expanded="false" aria-controls="<%= sovereign_id %>">
-                  <strong><%= sovereign %></strong>
-                  <span class="badge bg-primary ms-2"><%= total_pubs %></span>
+                  <span class="d-flex w-100 align-items-center">
+                    <strong><%= sovereign %></strong>
+                    <span class="badge bg-primary ms-auto me-2"><%= total_pubs %></span>
+                  </span>
                 </button>
               </h2>
               <div id="<%= sovereign_id %>" class="accordion-collapse collapse" data-bs-parent="#studied-sovereigns">
@@ -100,5 +111,10 @@
              style="height: 400px;"></div>
       </div>
     </div>
+    <p class="text-muted small mt-2 mb-0">
+      EEZ data: Flanders Marine Institute (2023). Maritime Boundaries Geodatabase: Maritime Boundaries and Exclusive Economic Zones (200NM), version 12. Available online at
+      <%= link_to "marineregions.org", "https://www.marineregions.org/", target: "_blank" %>.
+      <%= link_to "https://doi.org/10.14284/632", "https://doi.org/10.14284/632", target: "_blank" %>
+    </p>
   </div>
 </div>

--- a/app/views/eezs/show.html.erb
+++ b/app/views/eezs/show.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "layouts/page_title",
            locals: {
              title: @eez.territory,
-             subtitle: @eez.sovereign,
+             supertitle: @eez.sovereign,
              breadcrumbs: [["EEZ / Countries", eezs_path], [@eez.territory, nil]]
            } %>
 
@@ -30,7 +30,7 @@
     <div class="card mb-3">
       <div class="card-header">
         <strong>Locations</strong>
-        <span class="text-muted">(<%= @locations.size %>)</span>
+        <span class="text-muted">(<%= @locations.length %>)</span>
       </div>
       <% if @locations.any? %>
         <ul class="list-group list-group-flush">

--- a/app/views/eezs/show.html.erb
+++ b/app/views/eezs/show.html.erb
@@ -1,0 +1,71 @@
+<%= render partial: "layouts/page_title",
+           locals: {
+             title: @eez.territory,
+             subtitle: @eez.sovereign,
+             breadcrumbs: [["EEZ / Countries", eezs_path], [@eez.territory, nil]]
+           } %>
+
+<div class="row">
+  <div class="col-sm-8">
+    <div class="card mb-3">
+      <div class="card-header">
+        <strong>Details</strong>
+      </div>
+      <div class="card-body">
+        <dl class="row mb-0">
+          <dt class="col-sm-4">Sovereign</dt>
+          <dd class="col-sm-8"><%= @eez.sovereign %></dd>
+
+          <dt class="col-sm-4">Territory</dt>
+          <dd class="col-sm-8"><%= @eez.territory %></dd>
+
+          <dt class="col-sm-4">MRGID</dt>
+          <dd class="col-sm-8">
+            <%= link_to @eez.mrgid, "https://www.marineregions.org/gazetteer.php?p=details&id=#{@eez.mrgid}", target: "_blank", rel: "noopener" %>
+          </dd>
+        </dl>
+      </div>
+    </div>
+
+    <div class="card mb-3">
+      <div class="card-header">
+        <strong>Locations</strong>
+        <span class="text-muted">(<%= @locations.size %>)</span>
+      </div>
+      <% if @locations.any? %>
+        <ul class="list-group list-group-flush">
+          <% @locations.each do |location| %>
+            <li class="list-group-item d-flex justify-content-between align-items-center">
+              <%= link_to location.description, summary_path(model: "locations", id: location.id) %>
+              <span class="badge bg-secondary rounded-pill"><%= location.publications_count %></span>
+            </li>
+          <% end %>
+        </ul>
+      <% else %>
+        <div class="card-body">
+          <p class="text-muted mb-0">No locations assigned to this EEZ yet.</p>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="col-sm-4">
+    <% if @locations.any? %>
+      <div class="card mb-3">
+        <div class="card-header">
+          <strong>Map</strong>
+        </div>
+        <div class="card-body p-0" style="min-height: 300px;">
+          <%= turbo_frame_tag "world-map-eez_show",
+                src: world_map_path(
+                  key: "eez_show",
+                  model: Location,
+                  ids: @locations.map(&:id).join(','),
+                  height: 300
+                ),
+                loading: :lazy %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_link_categories.html.erb
+++ b/app/views/layouts/_link_categories.html.erb
@@ -5,14 +5,16 @@
 	</a>
 	<ul class="dropdown-menu">
 	   <li><span class="dropdown-item-text">Publications by ...</span></li>
-	   <li><%= link_to "Geographic location",
+	   <li><%= link_to "Geographic Location",
 	   				   locations_path, class: "dropdown-item" %></li>
-	   <li><%= link_to "Technology / platform",
+	   <li><%= link_to "Country / EEZ",
+	   				   eezs_path, class: "dropdown-item" %></li>
+	   <li><%= link_to "Technology / Platform",
 	   				   summary_path(model: "platforms", id: 10), class: "dropdown-item" %></li>
-	   <li><%= link_to "Research field",
+	   <li><%= link_to "Research Field",
 	   				   summary_path(model: "fields", id: 10), class: "dropdown-item" %></li>
-	   <li><%= link_to "Research focus",
+	   <li><%= link_to "Research Focus",
 	   				   summary_path(model: "focusgroups", id: 9), class: "dropdown-item" %></li>
-	   <li><%= link_to "Species list", species_index_path, class: "dropdown-item" %></li>
+	   <li><%= link_to "Species List", species_index_path, class: "dropdown-item" %></li>
 	</ul>
 </li>

--- a/app/views/layouts/_link_categories.html.erb
+++ b/app/views/layouts/_link_categories.html.erb
@@ -5,9 +5,9 @@
 	</a>
 	<ul class="dropdown-menu">
 	   <li><span class="dropdown-item-text">Publications by ...</span></li>
-	   <li><%= link_to "Geographic Location",
+	   <li><%= link_to "Location",
 	   				   locations_path, class: "dropdown-item" %></li>
-	   <li><%= link_to "Country / EEZ",
+	   <li><%= link_to "EEZ / Country",
 	   				   eezs_path, class: "dropdown-item" %></li>
 	   <li><%= link_to "Technology / Platform",
 	   				   summary_path(model: "platforms", id: 10), class: "dropdown-item" %></li>

--- a/app/views/locations/_form.html.erb
+++ b/app/views/locations/_form.html.erb
@@ -17,6 +17,16 @@
           <%= f.label :longitude, class: "required" %><br>
           <%= f.text_field :longitude, class: "form-control", required: true, placeholder: "e.g. 145.81735" %>
         </div>
+        <div class="mb-3">
+          <%= f.label :eez_id, "EEZ" %><br>
+          <%= f.select :eez_id,
+              options_for_select(
+                Eez.order(:sovereign, :territory).map { |e| ["#{e.territory} (#{e.sovereign})", e.id] },
+                location.eez_id
+              ),
+              { include_blank: "Select EEZ..." },
+              { class: "form-select", "data-tom-select" => "" } %>
+        </div>
         <% if location.publications.count > 0 %>
           <div class="alert alert-warning mb-0 py-2">
             <strong>Note:</strong> <%= location.publications.count %>

--- a/app/views/publications/_search_field.html.erb
+++ b/app/views/publications/_search_field.html.erb
@@ -97,6 +97,12 @@
             <%= search_param "Academic Fields", Publication.publication_fields, :fields, params, true %>
           </div>
         </div>
+        <div class="row">
+          <hr>
+          <div class="col-sm-6">
+            <%= search_param "EEZ / Country", Publication.publication_sovereigns, :sovereigns, params, true %>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/stats/_world.html.erb
+++ b/app/views/stats/_world.html.erb
@@ -2,18 +2,21 @@
   <div class="card-header">
     <strong>Our knowledge of mesophotic ecosystems across the world</strong>
   </div>
-  <div class="card-body">
-    <div class="row">
-      <div class="col-sm-6" style="min-height: 430px;">
-        <%= turbo_frame_tag "stats-world_publications", src: world_publications_path(:status => @status, :year => @year), loading: :lazy %>
-        <br><br>
-        <%= turbo_frame_tag "stats-world_users", src: world_users_path(:status => @status, :year => @year), loading: :lazy %>
-      </div>
+  <div class="card-body pb-0">
+    <div class="row mb-5">
       <div class="col-sm-6" style="min-height: 600px;">
         <%= turbo_frame_tag "stats-world_locations", src: world_locations_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
       <div class="col-sm-6" style="min-height: 600px;">
         <%= turbo_frame_tag "stats-world_sovereigns", src: world_sovereigns_path(:status => @status, :year => @year), loading: :lazy %>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-6">
+        <%= turbo_frame_tag "stats-world_publications", src: world_publications_path(:status => @status, :year => @year), loading: :lazy %>
+      </div>
+      <div class="col-sm-6">
+        <%= turbo_frame_tag "stats-world_users", src: world_users_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
     </div>
   </div>

--- a/app/views/stats/_world.html.erb
+++ b/app/views/stats/_world.html.erb
@@ -12,6 +12,9 @@
       <div class="col-sm-6" style="min-height: 600px;">
         <%= turbo_frame_tag "stats-world_locations", src: world_locations_path(:status => @status, :year => @year), loading: :lazy %>
       </div>
+      <div class="col-sm-6" style="min-height: 600px;">
+        <%= turbo_frame_tag "stats-world_sovereigns", src: world_sovereigns_path(:status => @status, :year => @year), loading: :lazy %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/stats/_world_sovereigns.html.erb
+++ b/app/views/stats/_world_sovereigns.html.erb
@@ -1,0 +1,8 @@
+<%= render partial: 'shared/stats_bar_graph',
+           locals: { title: 'Sovereigns_bar_graph',
+                     data: format_for_chart(@sovereigns, 25),
+                     height: 600,
+                     unit: 'Percentage' } %>
+<p>
+  Fig. 3d: <b>EEZ Sovereigns (top 25)</b><br>
+</p>

--- a/app/views/summary/_show.html.erb
+++ b/app/views/summary/_show.html.erb
@@ -9,6 +9,10 @@
 
     <%= render partial: "#{title.downcase}/dropdown_body", locals: { object: object } if lookup_context.template_exists? "dropdown_body", title.downcase, true %>
 
+    <% if object.respond_to?(:eez) && object.eez.present? %>
+      <p><strong>EEZ:</strong> <%= link_to "#{object.eez.territory} (#{object.eez.sovereign})", eez_path(object.eez) %></p>
+    <% end %>
+
     <div class="mb-3">
       <%= render partial: 'dropdown',
                  locals: { objects: objects, object: object, model: title.downcase } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Mesophotic::Application.routes.draw do
   resources :expeditions
   resources :photos
   resources :locations, except: :show
+  resources :eezs, only: [:index, :show]
   resources :meetings
   resources :presentations
   resources :species, except: :show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Mesophotic::Application.routes.draw do
   get :world_publications, controller: :stats
   get :world_users, controller: :stats
   get :world_locations, controller: :stats
+  get :world_sovereigns, controller: :stats
   get :time_refuge, controller: :stats
   get :time_mesophotic, controller: :stats
 

--- a/db/migrate/20260412025815_create_eezs.rb
+++ b/db/migrate/20260412025815_create_eezs.rb
@@ -1,0 +1,15 @@
+class CreateEezs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :eezs do |t|
+      t.integer :mrgid, null: false
+      t.string :geoname, null: false
+      t.string :sovereign, null: false
+      t.string :territory, null: false
+
+      t.timestamps
+    end
+
+    add_index :eezs, :mrgid, unique: true
+    add_index :eezs, :sovereign
+  end
+end

--- a/db/migrate/20260412030155_add_eez_id_to_locations.rb
+++ b/db/migrate/20260412030155_add_eez_id_to_locations.rb
@@ -1,0 +1,5 @@
+class AddEezIdToLocations < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :locations, :eez, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_022620) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_030155) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.integer "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -49,6 +49,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_022620) do
     t.string "request_response"
     t.integer "user_id"
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
+  end
+
+  create_table "eezs", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "geoname", null: false
+    t.integer "mrgid", null: false
+    t.string "sovereign", null: false
+    t.string "territory", null: false
+    t.datetime "updated_at", null: false
+    t.index ["mrgid"], name: "index_eezs_on_mrgid", unique: true
+    t.index ["sovereign"], name: "index_eezs_on_sovereign"
   end
 
   create_table "expeditions", force: :cascade do |t|
@@ -164,10 +175,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_022620) do
   create_table "locations", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.string "description", limit: 255
+    t.integer "eez_id"
     t.decimal "latitude", precision: 15, scale: 10
     t.decimal "longitude", precision: 15, scale: 10
     t.text "short_description"
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["eez_id"], name: "index_locations_on_eez_id"
   end
 
   create_table "locations_publications", id: false, force: :cascade do |t|
@@ -481,4 +494,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_022620) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "locations", "eezs"
 end

--- a/db/seeds/eezs.csv
+++ b/db/seeds/eezs.csv
@@ -1,0 +1,143 @@
+mrgid,geoname,sovereign,territory
+1000,Albania Exclusive Economic Zone,Albania,Albania
+1001,Australia Exclusive Economic Zone (Christmas Island),Australia,Christmas Island
+1002,Australia Exclusive Economic Zone (Coral Sea),Australia,Coral Sea
+1003,Australia Exclusive Economic Zone (Great Barrier Reef),Australia,Great Barrier Reef
+1004,Australia Exclusive Economic Zone (Northern Australia),Australia,Northern Australia
+1005,Australia Exclusive Economic Zone (Scott Reef),Australia,Scott Reef
+1006,Australia Exclusive Economic Zone (Southeastern Australia),Australia,Southeastern Australia
+1007,Australia Exclusive Economic Zone (Western Australia),Australia,Western Australia
+1008,Bahamas Exclusive Economic Zone,Bahamas,Bahamas
+1009,Barbados Exclusive Economic Zone,Barbados,Barbados
+1010,Belgium Exclusive Economic Zone,Belgium,Belgium
+1011,Belize Exclusive Economic Zone,Belize,Belize
+1012,Brazil Exclusive Economic Zone (Eastern Brazil),Brazil,Eastern Brazil
+1013,Brazil Exclusive Economic Zone (Fernando Noronha),Brazil,Fernando Noronha
+1014,Brazil Exclusive Economic Zone (St Peter and St Paul Archipelago),Brazil,St Peter and St Paul Archipelago
+1015,Brazil Exclusive Economic Zone (Trindade and Martin Vaz),Brazil,Trindade and Martin Vaz
+1016,Brunei Exclusive Economic Zone,Brunei,Brunei
+1017,Canada Exclusive Economic Zone,Canada,Canada
+1018,Cape Verde Exclusive Economic Zone,Cape Verde,Cape Verde
+1019,Chile Exclusive Economic Zone,Chile,Chile
+1020,Chile Exclusive Economic Zone (Easter Island),Chile,Easter Island
+1021,Chile Exclusive Economic Zone (Salas y Gomez Nazca Ridge),Chile,Salas y Gomez Nazca Ridge
+1022,China Exclusive Economic Zone,China,China
+1023,Colombia Exclusive Economic Zone,Colombia,Colombia
+1024,Comores Exclusive Economic Zone (Comoros),Comores,Comoros
+1025,Costa Rica Exclusive Economic Zone,Costa Rica,Costa Rica
+1026,Croatia Exclusive Economic Zone,Croatia,Croatia
+1027,Cuba Exclusive Economic Zone,Cuba,Cuba
+1028,Cyprus Exclusive Economic Zone,Cyprus,Cyprus
+1029,Denmark Exclusive Economic Zone,Denmark,Denmark
+1030,Djibouti Exclusive Economic Zone,Djibouti,Djibouti
+1031,Dominica Exclusive Economic Zone,Dominica,Dominica
+1032,Dominican Republic Exclusive Economic Zone,Dominican Republic,Dominican Republic
+1033,Ecuador Exclusive Economic Zone (Galapagos Islands),Ecuador,Galapagos Islands
+1034,Egypt Exclusive Economic Zone,Egypt,Egypt
+1035,El Salvador Exclusive Economic Zone,El Salvador,El Salvador
+1036,Fiji Exclusive Economic Zone,Fiji,Fiji
+1037,France Exclusive Economic Zone (Clipperton Island),France,Clipperton Island
+1038,France Exclusive Economic Zone,France,France
+1039,France Exclusive Economic Zone (French Guiana),France,French Guiana
+1040,France Exclusive Economic Zone (French Polynesia),France,French Polynesia
+1041,France Exclusive Economic Zone (Guadeloupe),France,Guadeloupe
+1042,France Exclusive Economic Zone (La Perouse),France,La Perouse
+1043,France Exclusive Economic Zone (Martinique),France,Martinique
+1044,France Exclusive Economic Zone (Mayotte),France,Mayotte
+1045,France Exclusive Economic Zone (New Caledonia),France,New Caledonia
+1046,France Exclusive Economic Zone (Reunion Islands),France,Reunion Islands
+1047,Germany Exclusive Economic Zone,Germany,Germany
+1048,Greece Exclusive Economic Zone,Greece,Greece
+1049,Grenada Exclusive Economic Zone,Grenada,Grenada
+1050,Haiti Exclusive Economic Zone (Navassa Island),Haiti,Navassa Island
+1051,High Seas Exclusive Economic Zone (Saya de Malha Bank),High Seas,Saya de Malha Bank
+1052,Honduras Exclusive Economic Zone (Bay Islands),Honduras,Bay Islands
+1053,India Exclusive Economic Zone (Andaman and Nicobar Islands),India,Andaman and Nicobar Islands
+1054,India Exclusive Economic Zone (Bay of Bengal),India,Bay of Bengal
+1055,India Exclusive Economic Zone,India,India
+1056,India Exclusive Economic Zone (Laccadive Sea),India,Laccadive Sea
+1057,Indonesia Exclusive Economic Zone,Indonesia,Indonesia
+1058,Iran Exclusive Economic Zone,Iran,Iran
+1059,Ireland Exclusive Economic Zone,Ireland,Ireland
+1060,Israel Exclusive Economic Zone,Israel,Israel
+1061,Italy Exclusive Economic Zone,Italy,Italy
+1062,Jamaica Exclusive Economic Zone,Jamaica,Jamaica
+1063,Japan Exclusive Economic Zone,Japan,Japan
+1064,Japan Exclusive Economic Zone (Ogasawara Islands),Japan,Ogasawara Islands
+1065,Japan Exclusive Economic Zone (Ryukyu Islands),Japan,Ryukyu Islands
+1066,Kiribati Exclusive Economic Zone,Kiribati,Kiribati
+1067,Lebanon Exclusive Economic Zone,Lebanon,Lebanon
+1068,Madagascar Exclusive Economic Zone,Madagascar,Madagascar
+1069,Malaysia Exclusive Economic Zone,Malaysia,Malaysia
+1070,Maldives Exclusive Economic Zone,Maldives,Maldives
+1071,Malta Exclusive Economic Zone,Malta,Malta
+1072,Marshall Islands Exclusive Economic Zone,Marshall Islands,Marshall Islands
+1073,Mauritius Exclusive Economic Zone (Chagos Archipelago),Mauritius,Chagos Archipelago
+1074,Mauritius Exclusive Economic Zone,Mauritius,Mauritius
+1075,Mexico Exclusive Economic Zone (Baja California),Mexico,Baja California
+1076,Mexico Exclusive Economic Zone (Gulf of Mexico),Mexico,Gulf of Mexico
+1077,Mexico Exclusive Economic Zone,Mexico,Mexico
+1078,Micronesia Exclusive Economic Zone (Caroline Islands),Micronesia,Caroline Islands
+1079,Micronesia Exclusive Economic Zone (Chuuk atoll),Micronesia,Chuuk atoll
+1080,Montenegro Exclusive Economic Zone,Montenegro,Montenegro
+1081,Morocco Exclusive Economic Zone,Morocco,Morocco
+1082,Mozambique Exclusive Economic Zone,Mozambique,Mozambique
+1083,Myanmar Exclusive Economic Zone,Myanmar,Myanmar
+1084,Netherlands Exclusive Economic Zone (Aruba),Netherlands,Aruba
+1085,Netherlands Exclusive Economic Zone (Bonaire),Netherlands,Bonaire
+1086,Netherlands Exclusive Economic Zone (Curacao),Netherlands,Curacao
+1087,Netherlands Exclusive Economic Zone,Netherlands,Netherlands
+1088,Netherlands Exclusive Economic Zone (Saba Bank),Netherlands,Saba Bank
+1089,New Zealand Exclusive Economic Zone (Cook Islands),New Zealand,Cook Islands
+1090,New Zealand Exclusive Economic Zone,New Zealand,New Zealand
+1091,Norway Exclusive Economic Zone,Norway,Norway
+1092,Oman Exclusive Economic Zone,Oman,Oman
+1093,Palau Exclusive Economic Zone,Palau,Palau
+1094,Panama Exclusive Economic Zone,Panama,Panama
+1095,Papua New Guinea Exclusive Economic Zone,Papua New Guinea,Papua New Guinea
+1096,Peru Exclusive Economic Zone,Peru,Peru
+1097,Philippines Exclusive Economic Zone,Philippines,Philippines
+1098,Poland Exclusive Economic Zone,Poland,Poland
+1099,Portugal Exclusive Economic Zone (Azores),Portugal,Azores
+1100,Portugal Exclusive Economic Zone,Portugal,Portugal
+1101,Saint Kitts and Nevis Exclusive Economic Zone,Saint Kitts and Nevis,Saint Kitts and Nevis
+1102,Saint Lucia Exclusive Economic Zone,Saint Lucia,Saint Lucia
+1103,Saint Vincent and the Grenadines Exclusive Economic Zone (St Vincent),Saint Vincent and the Grenadines,St Vincent
+1104,Sao Tome and Principe Exclusive Economic Zone,Sao Tome and Principe,Sao Tome and Principe
+1105,Saudi Arabia Exclusive Economic Zone,Saudi Arabia,Saudi Arabia
+1106,Seychelles Exclusive Economic Zone,Seychelles,Seychelles
+1107,Singapore Exclusive Economic Zone,Singapore,Singapore
+1108,Solomon Islands Exclusive Economic Zone,Solomon Islands,Solomon Islands
+1109,South Africa Exclusive Economic Zone,South Africa,South Africa
+1110,South Korea Exclusive Economic Zone (Jejudo Island),South Korea,Jejudo Island
+1111,Spain Exclusive Economic Zone (Canary Islands),Spain,Canary Islands
+1112,Spain Exclusive Economic Zone,Spain,Spain
+1113,Sudan Exclusive Economic Zone,Sudan,Sudan
+1114,Sweden Exclusive Economic Zone,Sweden,Sweden
+1115,Taiwan Exclusive Economic Zone,Taiwan,Taiwan
+1116,Tanzania Exclusive Economic Zone,Tanzania,Tanzania
+1117,Tonga Exclusive Economic Zone,Tonga,Tonga
+1118,Trinidad and Tobago Exclusive Economic Zone,Trinidad and Tobago,Trinidad and Tobago
+1119,Tunisia Exclusive Economic Zone,Tunisia,Tunisia
+1120,Turkey Exclusive Economic Zone,Turkey,Turkey
+1121,USA Exclusive Economic Zone (American Samoa),USA,American Samoa
+1122,USA Exclusive Economic Zone (Guam),USA,Guam
+1123,USA Exclusive Economic Zone (Gulf of Mexico),USA,Gulf of Mexico
+1124,USA Exclusive Economic Zone (Hawaii),USA,Hawaii
+1125,USA Exclusive Economic Zone (Johnston Atoll),USA,Johnston Atoll
+1126,USA Exclusive Economic Zone (Mariana Islands),USA,Mariana Islands
+1127,USA Exclusive Economic Zone (Puerto Rico),USA,Puerto Rico
+1128,USA Exclusive Economic Zone (Pulley Ridge),USA,Pulley Ridge
+1129,USA Exclusive Economic Zone (US Virgin Islands),USA,US Virgin Islands
+1130,USA Exclusive Economic Zone,USA,USA
+1131,United Kingdom Exclusive Economic Zone (Bermuda),United Kingdom,Bermuda
+1132,United Kingdom Exclusive Economic Zone (British Virgin Islands),United Kingdom,British Virgin Islands
+1133,United Kingdom Exclusive Economic Zone (Cayman Islands),United Kingdom,Cayman Islands
+1134,United Kingdom Exclusive Economic Zone (England),United Kingdom,England
+1135,United Kingdom Exclusive Economic Zone (Montserrat),United Kingdom,Montserrat
+1136,United Kingdom Exclusive Economic Zone (Pitcairn Islands),United Kingdom,Pitcairn Islands
+1137,United Kingdom Exclusive Economic Zone (Scotland),United Kingdom,Scotland
+1138,United Kingdom Exclusive Economic Zone (Turks and Caicos),United Kingdom,Turks and Caicos
+1139,Vanuatu Exclusive Economic Zone,Vanuatu,Vanuatu
+1140,Venezuela Exclusive Economic Zone,Venezuela,Venezuela
+1141,Vietnam Exclusive Economic Zone,Vietnam,Vietnam

--- a/db/seeds/eezs.csv
+++ b/db/seeds/eezs.csv
@@ -1,143 +1,286 @@
-mrgid,geoname,sovereign,territory
-1000,Albania Exclusive Economic Zone,Albania,Albania
-1001,Australia Exclusive Economic Zone (Christmas Island),Australia,Christmas Island
-1002,Australia Exclusive Economic Zone (Coral Sea),Australia,Coral Sea
-1003,Australia Exclusive Economic Zone (Great Barrier Reef),Australia,Great Barrier Reef
-1004,Australia Exclusive Economic Zone (Northern Australia),Australia,Northern Australia
-1005,Australia Exclusive Economic Zone (Scott Reef),Australia,Scott Reef
-1006,Australia Exclusive Economic Zone (Southeastern Australia),Australia,Southeastern Australia
-1007,Australia Exclusive Economic Zone (Western Australia),Australia,Western Australia
-1008,Bahamas Exclusive Economic Zone,Bahamas,Bahamas
-1009,Barbados Exclusive Economic Zone,Barbados,Barbados
-1010,Belgium Exclusive Economic Zone,Belgium,Belgium
-1011,Belize Exclusive Economic Zone,Belize,Belize
-1012,Brazil Exclusive Economic Zone (Eastern Brazil),Brazil,Eastern Brazil
-1013,Brazil Exclusive Economic Zone (Fernando Noronha),Brazil,Fernando Noronha
-1014,Brazil Exclusive Economic Zone (St Peter and St Paul Archipelago),Brazil,St Peter and St Paul Archipelago
-1015,Brazil Exclusive Economic Zone (Trindade and Martin Vaz),Brazil,Trindade and Martin Vaz
-1016,Brunei Exclusive Economic Zone,Brunei,Brunei
-1017,Canada Exclusive Economic Zone,Canada,Canada
-1018,Cape Verde Exclusive Economic Zone,Cape Verde,Cape Verde
-1019,Chile Exclusive Economic Zone,Chile,Chile
-1020,Chile Exclusive Economic Zone (Easter Island),Chile,Easter Island
-1021,Chile Exclusive Economic Zone (Salas y Gomez Nazca Ridge),Chile,Salas y Gomez Nazca Ridge
-1022,China Exclusive Economic Zone,China,China
-1023,Colombia Exclusive Economic Zone,Colombia,Colombia
-1024,Comores Exclusive Economic Zone (Comoros),Comores,Comoros
-1025,Costa Rica Exclusive Economic Zone,Costa Rica,Costa Rica
-1026,Croatia Exclusive Economic Zone,Croatia,Croatia
-1027,Cuba Exclusive Economic Zone,Cuba,Cuba
-1028,Cyprus Exclusive Economic Zone,Cyprus,Cyprus
-1029,Denmark Exclusive Economic Zone,Denmark,Denmark
-1030,Djibouti Exclusive Economic Zone,Djibouti,Djibouti
-1031,Dominica Exclusive Economic Zone,Dominica,Dominica
-1032,Dominican Republic Exclusive Economic Zone,Dominican Republic,Dominican Republic
-1033,Ecuador Exclusive Economic Zone (Galapagos Islands),Ecuador,Galapagos Islands
-1034,Egypt Exclusive Economic Zone,Egypt,Egypt
-1035,El Salvador Exclusive Economic Zone,El Salvador,El Salvador
-1036,Fiji Exclusive Economic Zone,Fiji,Fiji
-1037,France Exclusive Economic Zone (Clipperton Island),France,Clipperton Island
-1038,France Exclusive Economic Zone,France,France
-1039,France Exclusive Economic Zone (French Guiana),France,French Guiana
-1040,France Exclusive Economic Zone (French Polynesia),France,French Polynesia
-1041,France Exclusive Economic Zone (Guadeloupe),France,Guadeloupe
-1042,France Exclusive Economic Zone (La Perouse),France,La Perouse
-1043,France Exclusive Economic Zone (Martinique),France,Martinique
-1044,France Exclusive Economic Zone (Mayotte),France,Mayotte
-1045,France Exclusive Economic Zone (New Caledonia),France,New Caledonia
-1046,France Exclusive Economic Zone (Reunion Islands),France,Reunion Islands
-1047,Germany Exclusive Economic Zone,Germany,Germany
-1048,Greece Exclusive Economic Zone,Greece,Greece
-1049,Grenada Exclusive Economic Zone,Grenada,Grenada
-1050,Haiti Exclusive Economic Zone (Navassa Island),Haiti,Navassa Island
-1051,High Seas Exclusive Economic Zone (Saya de Malha Bank),High Seas,Saya de Malha Bank
-1052,Honduras Exclusive Economic Zone (Bay Islands),Honduras,Bay Islands
-1053,India Exclusive Economic Zone (Andaman and Nicobar Islands),India,Andaman and Nicobar Islands
-1054,India Exclusive Economic Zone (Bay of Bengal),India,Bay of Bengal
-1055,India Exclusive Economic Zone,India,India
-1056,India Exclusive Economic Zone (Laccadive Sea),India,Laccadive Sea
-1057,Indonesia Exclusive Economic Zone,Indonesia,Indonesia
-1058,Iran Exclusive Economic Zone,Iran,Iran
-1059,Ireland Exclusive Economic Zone,Ireland,Ireland
-1060,Israel Exclusive Economic Zone,Israel,Israel
-1061,Italy Exclusive Economic Zone,Italy,Italy
-1062,Jamaica Exclusive Economic Zone,Jamaica,Jamaica
-1063,Japan Exclusive Economic Zone,Japan,Japan
-1064,Japan Exclusive Economic Zone (Ogasawara Islands),Japan,Ogasawara Islands
-1065,Japan Exclusive Economic Zone (Ryukyu Islands),Japan,Ryukyu Islands
-1066,Kiribati Exclusive Economic Zone,Kiribati,Kiribati
-1067,Lebanon Exclusive Economic Zone,Lebanon,Lebanon
-1068,Madagascar Exclusive Economic Zone,Madagascar,Madagascar
-1069,Malaysia Exclusive Economic Zone,Malaysia,Malaysia
-1070,Maldives Exclusive Economic Zone,Maldives,Maldives
-1071,Malta Exclusive Economic Zone,Malta,Malta
-1072,Marshall Islands Exclusive Economic Zone,Marshall Islands,Marshall Islands
-1073,Mauritius Exclusive Economic Zone (Chagos Archipelago),Mauritius,Chagos Archipelago
-1074,Mauritius Exclusive Economic Zone,Mauritius,Mauritius
-1075,Mexico Exclusive Economic Zone (Baja California),Mexico,Baja California
-1076,Mexico Exclusive Economic Zone (Gulf of Mexico),Mexico,Gulf of Mexico
-1077,Mexico Exclusive Economic Zone,Mexico,Mexico
-1078,Micronesia Exclusive Economic Zone (Caroline Islands),Micronesia,Caroline Islands
-1079,Micronesia Exclusive Economic Zone (Chuuk atoll),Micronesia,Chuuk atoll
-1080,Montenegro Exclusive Economic Zone,Montenegro,Montenegro
-1081,Morocco Exclusive Economic Zone,Morocco,Morocco
-1082,Mozambique Exclusive Economic Zone,Mozambique,Mozambique
-1083,Myanmar Exclusive Economic Zone,Myanmar,Myanmar
-1084,Netherlands Exclusive Economic Zone (Aruba),Netherlands,Aruba
-1085,Netherlands Exclusive Economic Zone (Bonaire),Netherlands,Bonaire
-1086,Netherlands Exclusive Economic Zone (Curacao),Netherlands,Curacao
-1087,Netherlands Exclusive Economic Zone,Netherlands,Netherlands
-1088,Netherlands Exclusive Economic Zone (Saba Bank),Netherlands,Saba Bank
-1089,New Zealand Exclusive Economic Zone (Cook Islands),New Zealand,Cook Islands
-1090,New Zealand Exclusive Economic Zone,New Zealand,New Zealand
-1091,Norway Exclusive Economic Zone,Norway,Norway
-1092,Oman Exclusive Economic Zone,Oman,Oman
-1093,Palau Exclusive Economic Zone,Palau,Palau
-1094,Panama Exclusive Economic Zone,Panama,Panama
-1095,Papua New Guinea Exclusive Economic Zone,Papua New Guinea,Papua New Guinea
-1096,Peru Exclusive Economic Zone,Peru,Peru
-1097,Philippines Exclusive Economic Zone,Philippines,Philippines
-1098,Poland Exclusive Economic Zone,Poland,Poland
-1099,Portugal Exclusive Economic Zone (Azores),Portugal,Azores
-1100,Portugal Exclusive Economic Zone,Portugal,Portugal
-1101,Saint Kitts and Nevis Exclusive Economic Zone,Saint Kitts and Nevis,Saint Kitts and Nevis
-1102,Saint Lucia Exclusive Economic Zone,Saint Lucia,Saint Lucia
-1103,Saint Vincent and the Grenadines Exclusive Economic Zone (St Vincent),Saint Vincent and the Grenadines,St Vincent
-1104,Sao Tome and Principe Exclusive Economic Zone,Sao Tome and Principe,Sao Tome and Principe
-1105,Saudi Arabia Exclusive Economic Zone,Saudi Arabia,Saudi Arabia
-1106,Seychelles Exclusive Economic Zone,Seychelles,Seychelles
-1107,Singapore Exclusive Economic Zone,Singapore,Singapore
-1108,Solomon Islands Exclusive Economic Zone,Solomon Islands,Solomon Islands
-1109,South Africa Exclusive Economic Zone,South Africa,South Africa
-1110,South Korea Exclusive Economic Zone (Jejudo Island),South Korea,Jejudo Island
-1111,Spain Exclusive Economic Zone (Canary Islands),Spain,Canary Islands
-1112,Spain Exclusive Economic Zone,Spain,Spain
-1113,Sudan Exclusive Economic Zone,Sudan,Sudan
-1114,Sweden Exclusive Economic Zone,Sweden,Sweden
-1115,Taiwan Exclusive Economic Zone,Taiwan,Taiwan
-1116,Tanzania Exclusive Economic Zone,Tanzania,Tanzania
-1117,Tonga Exclusive Economic Zone,Tonga,Tonga
-1118,Trinidad and Tobago Exclusive Economic Zone,Trinidad and Tobago,Trinidad and Tobago
-1119,Tunisia Exclusive Economic Zone,Tunisia,Tunisia
-1120,Turkey Exclusive Economic Zone,Turkey,Turkey
-1121,USA Exclusive Economic Zone (American Samoa),USA,American Samoa
-1122,USA Exclusive Economic Zone (Guam),USA,Guam
-1123,USA Exclusive Economic Zone (Gulf of Mexico),USA,Gulf of Mexico
-1124,USA Exclusive Economic Zone (Hawaii),USA,Hawaii
-1125,USA Exclusive Economic Zone (Johnston Atoll),USA,Johnston Atoll
-1126,USA Exclusive Economic Zone (Mariana Islands),USA,Mariana Islands
-1127,USA Exclusive Economic Zone (Puerto Rico),USA,Puerto Rico
-1128,USA Exclusive Economic Zone (Pulley Ridge),USA,Pulley Ridge
-1129,USA Exclusive Economic Zone (US Virgin Islands),USA,US Virgin Islands
-1130,USA Exclusive Economic Zone,USA,USA
-1131,United Kingdom Exclusive Economic Zone (Bermuda),United Kingdom,Bermuda
-1132,United Kingdom Exclusive Economic Zone (British Virgin Islands),United Kingdom,British Virgin Islands
-1133,United Kingdom Exclusive Economic Zone (Cayman Islands),United Kingdom,Cayman Islands
-1134,United Kingdom Exclusive Economic Zone (England),United Kingdom,England
-1135,United Kingdom Exclusive Economic Zone (Montserrat),United Kingdom,Montserrat
-1136,United Kingdom Exclusive Economic Zone (Pitcairn Islands),United Kingdom,Pitcairn Islands
-1137,United Kingdom Exclusive Economic Zone (Scotland),United Kingdom,Scotland
-1138,United Kingdom Exclusive Economic Zone (Turks and Caicos),United Kingdom,Turks and Caicos
-1139,Vanuatu Exclusive Economic Zone,Vanuatu,Vanuatu
-1140,Venezuela Exclusive Economic Zone,Venezuela,Venezuela
-1141,Vietnam Exclusive Economic Zone,Vietnam,Vietnam
+mrgid,geoname,sovereign,territory,pol_type,iso_sov1,area_km2
+8444,United States Exclusive Economic Zone (American Samoa),United States,American Samoa,200NM,USA,405830
+8379,British Exclusive Economic Zone (Ascension),United Kingdom,Ascension,200NM,GBR,446005
+8446,New Zealand Exclusive Economic Zone (Cook Islands),New Zealand,Cook Islands,200NM,NZL,1969553
+8389,Overlapping claim Falkland / Malvinas Islands: United Kingdom / Argentina,United Kingdom,Falkland / Malvinas Islands,Overlapping claim,GBR,550566
+8440,French Exclusive Economic Zone (French Polynesia),France,French Polynesia,200NM,FRA,4766689
+8439,British Exclusive Economic Zone (Pitcairn),United Kingdom,Pitcairn,200NM,GBR,842291
+8380,British Exclusive Economic Zone (Saint Helena),United Kingdom,Saint Helena,200NM,GBR,449215
+8445,Samoan Exclusive Economic Zone,Samoa,Samoa,200NM,WSM,130480
+8448,Tongan Exclusive Economic Zone,Tonga,Tonga,200NM,TON,666052
+8382,British Exclusive Economic Zone (Tristan da Cunha),United Kingdom,Tristan da Cunha,200NM,GBR,758168
+8465,Chilean Exclusive Economic Zone,Chile,Chile,200NM,CHL,2488052
+8447,New Zealand Exclusive Economic Zone (Niue),New Zealand,Niue,200NM,NZL,318140
+48961,Joint regime area: Uruguay / Argentina,Uruguay,Uruguay,Joint regime,URY,41414
+48962,Joint regime area: Peru / Ecuador,Peru,Peru,Joint regime,PER,16091
+8467,Uruguayan Exclusive Economic Zone,Uruguay,Uruguay,200NM,URY,143092
+8449,New Zealand Exclusive Economic Zone (Tokelau),New Zealand,Tokelau,200NM,NZL,320548
+8432,Peruvian Exclusive Economic Zone,Peru,Peru,200NM,PER,854698
+22756,Chilean Exclusive Economic Zone (Islas San Félix and San Ambrosio),Chile,Islas San Félix and San Ambrosio,200NM,CHL,450960
+21787,Chilean Exclusive Economic Zone (Easter Island),Chile,Easter Island,200NM,CHL,729763
+8381,Brazilian Exclusive Economic Zone (Trindade),Brazil,Trindade,200NM,BRA,472481
+8450,Kiribati Exclusive Economic Zone (Phoenix Group),Kiribati,Phoenix Group,200NM,KIR,745782
+8466,Argentinian Exclusive Economic Zone,Argentina,Argentina,200NM,ARG,1075192
+8386,French Exclusive Economic Zone (Amsterdam and Saint Paul Islands),France,Amsterdam and Saint Paul Islands,200NM,FRA,512188
+8309,Australian Exclusive Economic Zone (Christmas Island),Australia,Christmas Island,200NM,AUS,327994
+8308,Australian Exclusive Economic Zone (Cocos Islands),Australia,Cocos Islands,200NM,AUS,467440
+8334,Comoran Exclusive Economic Zone,Comores,Comores,200NM,COM,164476
+8385,French Exclusive Economic Zone (Crozet Islands),France,Crozet Islands,200NM,FRA,575454
+48944,Overlapping claim Mayotte: France / Comores,France,Mayotte,Overlapping claim,FRA,66738
+48946,Overlapping claim Ile Tromelin: France / Madagascar / Republic of Mauritius,France,Ile Tromelin,Overlapping claim,FRA,274555
+8388,Australian Exclusive Economic Zone (Heard and McDonald Islands),Australia,Heard and McDonald Islands,200NM,AUS,417321
+8387,French Exclusive Economic Zone (Kerguélen),France,Kerguélen,200NM,FRA,550817
+8348,Madagascan Exclusive Economic Zone,Madagascar,Madagascar,200NM,MDG,1196285
+8396,South African Exclusive Economic Zone,South Africa,South Africa,200NM,ZAF,1072679
+8312,French Exclusive Economic Zone (New Caledonia),France,New Caledonia,200NM,FRA,1175971
+8310,Australian Exclusive Economic Zone (Norfolk Island),Australia,Norfolk Island,200NM,AUS,430600
+8343,Mauritian Exclusive Economic Zone,Republic of Mauritius,Republic of Mauritius,200NM,MUS,1278182
+8338,French Exclusive Economic Zone (Réunion),France,Réunion,200NM,FRA,315151
+8313,Vanuatuan Exclusive Economic Zone,Vanuatu,Vanuatu,200NM,VUT,625850
+8395,Namibian Exclusive Economic Zone,Namibia,Namibia,200NM,NAM,562212
+21791,Timorese Exclusive Economic Zone (Oecusse),East Timor,Oecusse,200NM,TLS,1826
+8394,Congolese (Republic of) Exclusive Economic Zone,Republic of the Congo,Republic of the Congo,200NM,COG,33807
+8478,Angolan Exclusive Economic Zone,Angola,Angola,200NM,AGO,495866
+8347,Mozambican Exclusive Economic Zone,Mozambique,Mozambique,200NM,MOZ,566292
+8349,Kenyan Exclusive Economic Zone,Kenya,Kenya,200NM,KEN,124028
+21798,Joint regime area Torres Strait Treaty: Papua New Guinea / Australia,Papua New Guinea,Papua New Guinea,Joint regime,PNG,2621
+8384,South African Exclusive Economic Zone (Prince Edward Islands),South Africa,Prince Edward Islands,200NM,ZAF,474897
+8479,Tanzanian Exclusive Economic Zone,Tanzania,Tanzania,200NM,TZA,241567
+8314,Solomon Islands Exclusive Economic Zone,Solomon Islands,Solomon Islands,200NM,SLB,1602781
+8337,Seychellois Exclusive Economic Zone,Seychelles,Seychelles,200NM,SYC,1341524
+48945,Overlapping claim Glorioso Islands: France / Madagascar,Madagascar,Glorioso Islands,Overlapping claim,MDG,43506
+8341,French Exclusive Economic Zone (Europa Island),France,Europa Island,200NM,FRA,127936
+48948,Overlapping claim Matthew and Hunter Islands: France / Vanuatu,France,Matthew and Hunter Islands,Overlapping claim,FRA,187184
+8477,Congolese (Democratic Republic of) Exclusive Economic Zone,Democratic Republic of the Congo,Democratic Republic of the Congo,200NM,COD,13373
+8323,Australian Exclusive Economic Zone,Australia,Australia,200NM,AUS,6873830
+8311,Australian Exclusive Economic Zone (Macquarie Island),Australia,Macquarie Island,200NM,AUS,476278
+8339,French Exclusive Economic Zone (Juan de Nova Island),France,Juan de Nova Island,200NM,FRA,62775
+8340,French Exclusive Economic Zone (Bassas da India),France,Bassas da India,200NM,FRA,120706
+8758,Timorese Exclusive Economic Zone,East Timor,East Timor,200NM,TLS,75647
+8412,British Exclusive Economic Zone (Anguilla),United Kingdom,Anguilla,200NM,GBR,90164
+8414,Antiguan and Barbudan Exclusive Economic Zone,Antigua and Barbuda,Antigua and Barbuda,200NM,ATG,111568
+26519,Dutch Exclusive Economic Zone (Aruba),Netherlands,Aruba,200NM,NLD,30015
+8361,Portuguese Exclusive Economic Zone (Azores),Portugal,Azores,200NM,PRT,960421
+8404,Bahamian Exclusive Economic Zone,Bahamas,Bahamas,200NM,BHS,619785
+8418,Barbadian Exclusive Economic Zone,Barbados,Barbados,200NM,BRB,185007
+8429,Mexican Exclusive Economic Zone,Mexico,Mexico,200NM,MEX,3187013
+26520,Dutch Exclusive Economic Zone (Bonaire),Netherlands,Bonaire,200NM,NLD,13005
+8411,British Exclusive Economic Zone (British Virgin Islands),United Kingdom,British Virgin Islands,200NM,GBR,81555
+8362,Cape Verdean Exclusive Economic Zone,Cape Verde,Cape Verde,200NM,CPV,801936
+8364,Spanish Exclusive Economic Zone (Canary Islands),Spain,Canary Islands,200NM,ESP,445910
+8407,British Exclusive Economic Zone (Cayman Islands),United Kingdom,Cayman Islands,200NM,GBR,118291
+8401,French Exclusive Economic Zone (Clipperton Island),France,Clipperton Island,200NM,FRA,435657
+8423,Panamanian Exclusive Economic Zone,Panama,Panama,200NM,PAN,331318
+8424,Costa Rican Exclusive Economic Zone,Costa Rica,Costa Rica,200NM,CRI,581726
+26517,Dutch Exclusive Economic Zone (Curaçao),Netherlands,Curaçao,200NM,NLD,25401
+8417,Dominican Exclusive Economic Zone,Dominica,Dominica,200NM,DMA,28552
+8409,Dominican (Republic) Exclusive Economic Zone,Dominican Republic,Dominican Republic,200NM,DOM,350694
+8430,Guatemalan Exclusive Economic Zone,Guatemala,Guatemala,200NM,GTM,110695
+8435,Danish Exclusive Economic Zone (Faeroe),Denmark,Faeroe,200NM,DNK,265326
+8370,Gambian Exclusive Economic Zone,Gambia,Gambia,200NM,GMB,23097
+8365,Overlapping claim Gibraltar: United Kingdom / Spain,United Kingdom,Gibraltar,Overlapping claim,GIB,388
+8419,Grenadian Exclusive Economic Zone,Grenada,Grenada,200NM,GRD,25571
+33177,French Exclusive Economic Zone (Guadeloupe),France,Guadeloupe,200NM,FRA,90705
+8390,Sierra Leonean Exclusive Economic Zone,Sierra Leone,Sierra Leone,200NM,SLE,160584
+5680,Icelandic Exclusive Economic Zone,Iceland,Iceland,200NM,ISL,763239
+8459,Jamaican Exclusive Economic Zone,Jamaica,Jamaica,200NM,JAM,256909
+8363,Portuguese Exclusive Economic Zone (Madeira),Portugal,Madeira,200NM,PRT,452796
+8369,Mauritanian Exclusive Economic Zone,Mauritania,Mauritania,200NM,MRT,173180
+8415,British Exclusive Economic Zone (Montserrat),United Kingdom,Montserrat,200NM,GBR,7188
+48951,Overlapping claim Navassa Island: United States / Haiti / Jamaica,Haiti,Navassa Island,Overlapping claim,HTI,13890
+8443,United States Exclusive Economic Zone (Palmyra Atoll),United States,Palmyra Atoll,200NM,USA,353670
+33179,United States Exclusive Economic Zone (Puerto Rico),United States,Puerto Rico,200NM,USA,154661
+26518,Dutch Exclusive Economic Zone (Saba),Netherlands,Saba,200NM,NLD,9487
+48952,French Exclusive Economic Zone (Saint-Barthélemy),France,Saint-Barthélemy,200NM,FRA,4179
+26526,Dutch Exclusive Economic Zone (Sint-Eustatius),Netherlands,Sint-Eustatius,200NM,NLD,2176
+8413,Kittitian and Nevisian Exclusive Economic Zone,Saint Kitts and Nevis,Saint Kitts and Nevis,200NM,KNA,9502
+8416,Saint Lucian Exclusive Economic Zone,Saint Lucia,Saint Lucia,200NM,LCA,15413
+8495,French Exclusive Economic Zone (Collectivity of Saint Martin),France,Collectivity of Saint Martin,200NM,FRA,1100
+8494,French Exclusive Economic Zone (Saint-Pierre and Miquelon),France,Saint-Pierre and Miquelon,200NM,FRA,12414
+8421,Saint Vincentian Exclusive Economic Zone,Saint Vincent and the Grenadines,Saint Vincent and the Grenadines,200NM,VCT,36244
+21803,Dutch Exclusive Economic Zone (Sint-Maarten),Netherlands,Sint-Maarten,200NM,NLD,466
+8420,Trinidadian and Tobagonian Exclusive Economic Zone,Trinidad and Tobago,Trinidad and Tobago,200NM,TTO,76562
+8405,British Exclusive Economic Zone (Turks and Caicos Islands),United Kingdom,Turks and Caicos Islands,200NM,GBR,91025
+33180,United States Exclusive Economic Zone (United States Virgin Islands),United States,United States Virgin Islands,200NM,USA,38275
+5688,Portuguese Exclusive Economic Zone,Portugal,Portugal,200NM,PRT,315501
+8428,Salvadoran Exclusive Economic Zone,El Salvador,El Salvador,200NM,SLV,95099
+8457,Belizean Exclusive Economic Zone,Belize,Belize,200NM,BLZ,32862
+8406,Cuban Exclusive Economic Zone,Cuba,Cuba,200NM,CUB,352259
+8408,Haitian Exclusive Economic Zone,Haiti,Haiti,200NM,HTI,103485
+33178,French Exclusive Economic Zone (Martinique),France,Martinique,200NM,FRA,47787
+48964,Joint regime area: Senegal / Guinea-Bissau,Senegal,Senegal,Joint regime,SEN,63460
+48965,Overlapping claim: Venezuela / Netherlands (Aruba) / Dominican Republic,Venezuela,Venezuela,Overlapping claim,VEN,1113
+48966,Joint regime area: Spain / France,France,France,Joint regime,FRA,2859
+48967,Joint regime area: United Kingdom / Denmark (Faeroe Islands),United Kingdom,United Kingdom,Joint regime,GBR,8011
+48943,Overlapping claim: Canada / United States,Canada,Canada,Overlapping claim,CAN,24772
+48968,Joint regime area: Costa Rica / Ecuador (Galapagos),Costa Rica,Costa Rica,Joint regime,CRI,17337
+8425,Nicaraguan Exclusive Economic Zone,Nicaragua,Nicaragua,200NM,NIC,213813
+8460,Guyanese Exclusive Economic Zone,Guyana,Guyana,200NM,GUY,135060
+48969,Joint regime area: Barbados / Guyana,Barbados,Barbados,Joint regime,BRB,67
+48970,Joint regime area: Dominican Republic / Colombia,Dominican Republic,Dominican Republic,Joint regime,DOM,13111
+48971,Overlapping claim: Colombia / Dominican Republic / Venezuela,Colombia,Colombia,Overlapping claim,COL,869
+5681,Irish Exclusive Economic Zone,Ireland,Ireland,200NM,IRL,428004
+21788,British Exclusive Economic Zone (Guernsey),United Kingdom,Guernsey,200NM,GBR,3680
+21789,British Exclusive Economic Zone (Jersey),United Kingdom,Jersey,200NM,GBR,2332
+8371,Senegalese Exclusive Economic Zone,Senegal,Senegal,200NM,SEN,158358
+8471,Bissau-Guinean Exclusive Economic Zone,Guinea-Bissau,Guinea-Bissau,200NM,GNB,106870
+8472,Guinean Exclusive Economic Zone,Guinea,Guinea,200NM,GIN,102163
+8473,Ivorian Exclusive Economic Zone,Ivory Coast,Ivory Coast,200NM,CIV,171760
+33185,Overlapping claim: Guyana / Trinidad and Tobago / Venezuela,Guyana,Guyana,Overlapping claim,GUY,3612
+8391,Liberian Exclusive Economic Zone,Liberia,Liberia,200NM,LBR,251781
+21792,Joint regime area: Jamaica / Colombia,Jamaica,Jamaica,Joint regime,JAM,15247
+48972,Joint regime area: Honduras / United Kingdom (Cayman Islands),Honduras,Honduras,Joint regime,HND,2075
+48973,Joint regime area: Iceland / Denmark (Faeroe Islands),Denmark,Faeroe,Joint regime,DNK,1234
+8433,Venezuelan Exclusive Economic Zone,Venezuela,Venezuela,200NM,VEN,472546
+8427,Honduran Exclusive Economic Zone,Honduras,Honduras,200NM,HND,208636
+48974,Joint regime area: Ecuador / Colombia,Ecuador,Ecuador,Joint regime,ECU,18663
+48975,Joint regime area: Iceland / Norway (Jan Mayen),Iceland,Iceland,Joint regime,ISL,45532
+8493,Canadian Exclusive Economic Zone,Canada,Canada,200NM,CAN,5740658
+8368,Overlapping claim Western Sahara: Western Sahara / Morocco,Western Sahara,Western Sahara,Overlapping claim,ESH,284054
+8461,Surinamese Exclusive Economic Zone,Suriname,Suriname,200NM,SUR,133668
+8462,French Exclusive Economic Zone (French Guiana),France,French Guiana,200NM,FRA,131247
+48982,Overlapping claim: United States (Puerto Rico) / Dominican Republic,United States,Puerto Rico,Overlapping claim,USA,18297
+8452,United States Exclusive Economic Zone (Johnston Atoll),United States,Johnston Atoll,200NM,USA,442443
+8426,Colombian Exclusive Economic Zone,Colombia,Colombia,200NM,COL,718338
+62596,Colombian Exclusive Economic Zone (Serrana Bank),Colombia,Serrana Bank,200NM,COL,2838
+62598,Colombian Exclusive Economic Zone (Quitasueño Bank),Colombia,Quitasueño Bank,200NM,COL,3689
+48984,Colombian Exclusive Economic Zone (Serranilla Bank),Colombia,Serranilla Bank,200NM,COL,1552
+48985,Colombian Exclusive Economic Zone (Bajo Nuevo Bank),Colombia,Bajo Nuevo Bank,200NM,COL,1550
+8367,Moroccan Exclusive Economic Zone,Morocco,Morocco,200NM,MAR,280452
+49000,Overlapping claim Melilla: Spain / Morocco,Spain,Melilla,Overlapping claim,ESP,27
+49001,Overlapping claim Alhucemas Islands: Spain / Morocco,Spain,Alhucemas Islands,Overlapping claim,ESP,14
+48998,Overlapping claim Perejil Island: Spain / Morocco,Spain,Perejil Island,Overlapping claim,ESP,1
+49002,Overlapping claim Ceuta: Spain / Morocco,Spain,Ceuta,Overlapping claim,ESP,33
+48999,Overlapping claim Peñón de Vélez de la Gomera: Spain / Morocco,Spain,Peñón de Vélez de la Gomera,Overlapping claim,ESP,4
+48997,Overlapping claim Chafarinas Islands: Spain / Morocco,Spain,Chafarinas Islands,Overlapping claim,ESP,26
+8360,Emirati Exclusive Economic Zone,United Arab Emirates,United Arab Emirates,200NM,ARE,51674
+8376,Cypriote Exclusive Economic Zone,Cyprus,Cyprus,200NM,CYP,98450
+48947,"Overlapping claim Abu musa, Greater and Lesser Tunb: United Arab Emirates / Iran",United Arab Emirates,"Abu musa, Greater and Lesser Tunb",Overlapping claim,ARE,6173
+48956,Overlapping claim Doumeira Islands: Eritrea / Djibouti,Eritrea,Doumeira Islands,Overlapping claim,ERI,245
+8490,Egyptian Exclusive Economic Zone,Egypt,Egypt,200NM,EGY,242929
+8351,Eritrean Exclusive Economic Zone,Eritrea,Eritrea,200NM,ERI,78110
+5678,Georgian Exclusive Economic Zone,Georgia,Georgia,200NM,GEO,22944
+8469,Iranian Exclusive Economic Zone,Iran,Iran,200NM,IRN,215613
+8374,Lebanese Exclusive Economic Zone,Lebanon,Lebanon,200NM,LBN,18857
+8372,Libyan Exclusive Economic Zone,Libya,Libya,200NM,LBY,357386
+5685,Maltese Exclusive Economic Zone,Malta,Malta,200NM,MLT,52923
+8354,Omani Exclusive Economic Zone,Oman,Oman,200NM,OMN,556490
+8356,Saudi Arabian Exclusive Economic Zone,Saudi Arabia,Saudi Arabia,200NM,SAU,224157
+8346,Sri Lankan Exclusive Economic Zone,Sri Lanka,Sri Lanka,200NM,LKA,533559
+8373,Syrian Exclusive Economic Zone,Syria,Syria,200NM,SYR,10269
+8392,Togolese Exclusive Economic Zone,Togo,Togo,200NM,TGO,15447
+5679,Greek Exclusive Economic Zone,Greece,Greece,200NM,GRC,482936
+5697,Turkish Exclusive Economic Zone,Turkey,Turkey,200NM,TUR,262233
+21790,Monégasque Exclusive Economic Zone,Monaco,Monaco,200NM,MCO,288
+8366,Tunisian Exclusive Economic Zone,Tunisia,Tunisia,200NM,TUN,99701
+5691,Montenegrin Exclusive Economic Zone,Montenegro,Montenegro,200NM,MNE,6383
+5670,Albanian Exclusive Economic Zone,Albania,Albania,200NM,ALB,12165
+5672,Bulgarian Exclusive Economic Zone,Bulgaria,Bulgaria,200NM,BGR,34745
+48953,Palestinian Exclusive Economic Zone,Palestine,Palestine,200NM,PSE,1120
+8357,Kuwaiti Exclusive Economic Zone,Kuwait,Kuwait,200NM,KWT,10775
+8470,Iraqi Exclusive Economic Zone,Iraq,Iraq,200NM,IRQ,1342
+8358,Bahraini Exclusive Economic Zone,Bahrain,Bahrain,200NM,BHR,7516
+8468,Qatari Exclusive Economic Zone,Qatar,Qatar,200NM,QAT,31363
+8353,Yemeni Exclusive Economic Zone,Yemen,Yemen,200NM,YEM,527384
+8375,Israeli Exclusive Economic Zone,Israel,Israel,200NM,ISR,25955
+8491,Jordanian Exclusive Economic Zone,Jordan,Jordan,200NM,JOR,97
+8352,Djiboutian Exclusive Economic Zone,Djibouti,Djibouti,200NM,DJI,7223
+8481,Bangladeshi Exclusive Economic Zone,Bangladesh,Bangladesh,200NM,BGD,112166
+8474,Nigerian Exclusive Economic Zone,Nigeria,Nigeria,200NM,NGA,179048
+8475,Cameroonian Exclusive Economic Zone,Cameroon,Cameroon,200NM,CMR,15143
+21797,Joint regime area: São Tomé and Principe / Nigeria,São Tomé and Principe,São Tomé and Principe,Joint regime,STP,34534
+48976,Joint regime area: France / Italy,France,France,Joint regime,FRA,67
+22491,Bosnian and Herzegovinian Exclusive Economic Zone,Bosnia and Herzegovina,Bosnia and Herzegovina,200NM,BIH,13
+48957,United States Exclusive Economic Zone (Guam),United States,Guam,200NM,USA,208234
+8318,Marshallese Exclusive Economic Zone,Marshall Islands,Marshall Islands,200NM,MHL,2002220
+48980,United States Exclusive Economic Zone (Northern Mariana Islands),United States,Northern Mariana Islands,200NM,USA,763626
+8315,Palauan Exclusive Economic Zone,Palau,Palau,200NM,PLW,616431
+8322,Philippine Exclusive Economic Zone,Philippines,Philippines,200NM,PHL,1964764
+48954,Overlapping claim Senkaku Islands: Taiwan / Japan / China,Taiwan,Senkaku Islands,Overlapping claim,TWN,73794
+8485,Singaporean Exclusive Economic Zone,Singapore,Singapore,200NM,SGP,675
+8332,Thailand Exclusive Economic Zone,Thailand,Thailand,200NM,THA,298561
+8319,Overlapping claim Wake Island / Enenkio: United States / Marshall Islands,United States,Wake Island / Enenkio,Overlapping claim,USA,406970
+8484,Vietnamese Exclusive Economic Zone,Vietnam,Vietnam,200NM,VNM,752197
+21796,Joint regime area: South Korea / Japan,South Korea,South Korea,Joint regime,KOR,82610
+26521,Bruneian Exclusive Economic Zone,Brunei,Brunei,200NM,BRN,43038
+8321,Overlapping claim Taiwan: Taiwan / China,Taiwan,Taiwan,Overlapping claim,TWN,355433
+8328,North Korean Exclusive Economic Zone,North Korea,North Korea,200NM,PRK,114379
+8331,Cambodian Exclusive Economic Zone,Cambodia,Cambodia,200NM,KHM,48697
+8486,Chinese Exclusive Economic Zone,China,China,200NM,CHN,963556
+5675,Estonian Exclusive Economic Zone,Estonia,Estonia,200NM,EST,36451
+5676,Finnish Exclusive Economic Zone,Finland,Finland,200NM,FIN,81553
+5694,Swedish Exclusive Economic Zone,Sweden,Sweden,200NM,SWE,155386
+5684,Lithuanian Exclusive Economic Zone,Lithuania,Lithuania,200NM,LTU,6864
+48977,Joint regime area: Sweden / Norway,Norway,Norway,Joint regime,NOR,140
+3293,Belgian Exclusive Economic Zone,Belgium,Belgium,200NM,BEL,3531
+5668,Dutch Exclusive Economic Zone,Netherlands,Netherlands,200NM,NLD,64292
+5669,German Exclusive Economic Zone,Germany,Germany,200NM,DEU,56831
+5674,Danish Exclusive Economic Zone,Denmark,Denmark,200NM,DNK,104229
+5683,Latvian Exclusive Economic Zone,Latvia,Latvia,200NM,LVA,28322
+5673,Croatian Exclusive Economic Zone,Croatia,Croatia,200NM,HRV,55159
+5682,Italian Exclusive Economic Zone,Italy,Italy,200NM,ITA,536446
+5695,Overlapping claim Ukraine: Ukraine / Russia,Ukraine,Ukraine,Overlapping claim,UKR,136198
+5689,Romanian Exclusive Economic Zone,Romania,Romania,200NM,ROU,29606
+8487,Japanese Exclusive Economic Zone,Japan,Japan,200NM,JPN,4066513
+48950,Overlapping claim Kuril Islands: Japan / Russia,Japan,Kuril Islands,Overlapping claim,JPN,213723
+8333,Indian Exclusive Economic Zone (Andaman and Nicobar Islands),India,Andaman and Nicobar,200NM,IND,664448
+8359,Pakistani Exclusive Economic Zone,Pakistan,Pakistan,200NM,PAK,224361
+26523,Turkmen Exclusive Economic Zone,Turkmenistan,Turkmenistan,200NM,TKM,61226
+26524,Azerbaijani Exclusive Economic Zone,Azerbaijan,Azerbaijan,200NM,AZE,80614
+26522,Kazakh Exclusive Economic Zone,Kazakhstan,Kazakhstan,200NM,KAZ,114383
+8482,Myanma Exclusive Economic Zone,Myanmar,Myanmar,200NM,MMR,497460
+5687,Polish Exclusive Economic Zone,Poland,Poland,200NM,POL,30666
+8480,Indian Exclusive Economic Zone,India,India,200NM,IND,1659500
+26582,Overlapping claim Halaib Triangle: Sudan / Egypt,Sudan,Halaib Triangle,Overlapping claim,SDN,19734
+8393,Beninese Exclusive Economic Zone,Benin,Benin,200NM,BEN,35493
+5692,Slovenian Exclusive Economic Zone,Slovenia,Slovenia,200NM,SVN,214
+8483,Malaysian Exclusive Economic Zone,Malaysia,Malaysia,200NM,MYS,517589
+49003,Overlapping claim: South China Sea,China,China,Overlapping claim,CHN,338839
+50167,Joint regime area: Croatia / Slovenia,Croatia,Croatia,Joint regime,HRV,98
+8327,South Korean Exclusive Economic Zone,South Korea,South Korea,200NM,KOR,347671
+48955,Overlapping claim Liancourt Rocks: Japan / South Korea,Japan,Liancourt Rocks,Overlapping claim,JPN,1624
+50170,Overlapping claim: Qatar / Saudi Arabia / United Arab Emirates,Qatar,Qatar,Overlapping claim,QAT,126
+8455,New Zealand Exclusive Economic Zone,New Zealand,New Zealand,200NM,NZL,4104551
+8442,United States Exclusive Economic Zone (Jarvis Islands),United States,Jarvis Island,200NM,USA,323186
+8326,Tuvaluan Exclusive Economic Zone,Tuvalu,Tuvalu,200NM,TUV,753133
+8454,French Exclusive Economic Zone (Wallis and Futuna),France,Wallis and Futuna,200NM,FRA,250614
+8451,United States Exclusive Economic Zone (Howland and Baker Islands),United States,Howland and Baker Islands,200NM,USA,434894
+8325,Fijian Exclusive Economic Zone,Fiji,Fiji,200NM,FJI,1302114
+8464,Brazilian Exclusive Economic Zone,Brazil,Brazil,200NM,BRA,3205183
+8441,Kiribati Exclusive Economic Zone (Line Group),Kiribati,Line Group,200NM,KIR,1641193
+8488,Kiribati Exclusive Economic Zone (Gilbert Islands),Kiribati,Gilbert Islands,200NM,KIR,1053245
+8403,Ecuadorian Exclusive Economic Zone (Galapagos),Ecuador,Galapagos,200NM,ECU,841438
+8431,Ecuadorian Exclusive Economic Zone,Ecuador,Ecuador,200NM,ECU,236293
+8397,São Toméan Exclusive Economic Zone,Sao Tome and Principe,Sao Tome and Principe,200NM,STP,130844
+8316,Micronesian Exclusive Economic Zone,Micronesia,Micronesia,200NM,FSM,3007718
+8398,Equatorial Guinean Exclusive Economic Zone,Equatorial Guinea,Equatorial Guinea,200NM,GNQ,304133
+8345,Maldivian Exclusive Economic Zone,Maldives,Maldives,200NM,MDV,923833
+8324,Papua New Guinean Exclusive Economic Zone,Papua New Guinea,Papua New Guinea,200NM,PNG,2399617
+8350,Somali Exclusive Economic Zone,Federal Republic of Somalia,Federal Republic of Somalia,200NM,SOM,821444
+8317,Nauruan Exclusive Economic Zone,Nauru,Nauru,200NM,NRU,309261
+8476,Gabonese Exclusive Economic Zone,Gabon,Gabon,200NM,GAB,201759
+8492,Indonesian Exclusive Economic Zone,Indonesia,Indonesia,200NM,IDN,6019205
+48978,Joint regime area: United States / Russia,United States,United States,Joint regime,USA,8478
+5677,French Exclusive Economic Zone,France,France,200NM,FRA,348474
+8378,Algerian Exclusive Economic Zone,Algeria,Algeria,200NM,DZA,131193
+8400,Ghanaian Exclusive Economic Zone,Ghana,Ghana,200NM,GHA,227500
+8438,Danish Exclusive Economic Zone (Greenland),Denmark,Greenland,200NM,DNK,2268623
+5696,British Exclusive Economic Zone,United Kingdom,United Kingdom,200NM,GBR,727260
+8453,United States Exclusive Economic Zone (Hawaii),United States,Hawaii,200NM,USA,2474715
+33181,Norwegian Exclusive Economic Zone (Svalbard),Norway,Svalbard,200NM,NOR,796819
+5686,Norwegian Exclusive Economic Zone,Norway,Norway,200NM,NOR,931288
+5690,Russian Exclusive Economic Zone,Russia,Russia,200NM,RUS,7730566
+8437,Norwegian Exclusive Economic Zone (Jan Mayen),Norway,Jan Mayen,200NM,NOR,292907
+8463,United States Exclusive Economic Zone (Alaska),United States,Alaska,200NM,USA,3682912
+5693,Spanish Exclusive Economic Zone,Spain,Spain,200NM,ESP,561763
+62589,Mauritian Exclusive Economic Zone (Chagos Archipelago),Republic of Mauritius,Chagos Archipelago,200NM,MUS,647678
+8383,Overlapping claim South Georgia and the South Sandwich Islands: United Kingdom / Argentina,United Kingdom,South Georgia and the South Sandwich Islands,Overlapping claim,GBR,1237783
+8402,British Exclusive Economic Zone (Bermuda),United Kingdom,Bermuda,200NM,GBR,464389
+8456,United States Exclusive Economic Zone,United States,United States,200NM,USA,2450909
+8355,Sudanese Exclusive Economic Zone,Sudan,Sudan,200NM,SDN,62826
+64446,British Exclusive Economic Zone (Isle of Man),United Kingdom,Isle of Man,200NM,GBR,3961
+64460,Overlapping claim: Iraq / Iran,Iraq,Iraq,Overlapping claim,IRQ,28
+64430,Overlapping claim: Egypt / Libya,Egypt,Egypt,Overlapping claim,EGY,8114
+64431,Overlapping claim: Belize / Honduras,Belize,Belize,Overlapping claim,BLZ,1450
+64459,Joint regime area: Norway / Russia,Norway,Norway,Joint regime,NOR,3397
+64440,Overlapping claim: Malaysia / Singapore,Malaysia,Malaysia,Overlapping claim,MYS,287

--- a/docs/superpowers/plans/2026-04-12-eez-implementation.md
+++ b/docs/superpowers/plans/2026-04-12-eez-implementation.md
@@ -1,0 +1,1045 @@
+# EEZ Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Exclusive Economic Zone (EEZ) data to mesophotic.org, enabling browse-by-country, location metadata, publication filtering, stats, and colored map markers.
+
+**Architecture:** Flat `eezs` table with sovereign as a string column (grouped via scopes). Locations get a `belongs_to :eez` foreign key. Publications reach EEZ data through `locations -> eezs`. Full VLIZ Marine Regions v12 dataset seeded (~280 EEZ records). UI surfaces EEZ as index/show pages, location metadata, publication filters, stats chart, and colored map markers.
+
+**Tech Stack:** Rails 8.1, SQLite3, ERB, Highcharts Maps, Tom Select, Turbo Frames, Minitest
+
+**Spec:** `docs/superpowers/specs/2026-04-12-eez-design.md`
+
+---
+
+### Task 1: Migration and Eez Model
+
+**Files:**
+- Create: `db/migrate/TIMESTAMP_create_eezs.rb`
+- Create: `db/migrate/TIMESTAMP_add_eez_id_to_locations.rb`
+- Create: `app/models/eez.rb`
+- Modify: `app/models/location.rb:19` (add `belongs_to`)
+- Create: `test/models/eez_test.rb`
+- Create: `test/fixtures/eezs.yml`
+
+- [ ] **Step 1: Write Eez model tests**
+
+Create `test/models/eez_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class EezTest < ActiveSupport::TestCase
+  test "valid with all required fields" do
+    eez = Eez.new(mrgid: 99999, geoname: "Test EEZ", sovereign: "Testland", territory: "Test Territory")
+    assert eez.valid?
+  end
+
+  test "requires mrgid" do
+    eez = Eez.new(geoname: "Test", sovereign: "Test", territory: "Test")
+    assert_not eez.valid?
+    assert eez.errors[:mrgid].any?
+  end
+
+  test "requires unique mrgid" do
+    eez = Eez.new(mrgid: eezs(:australian_gbr).mrgid, geoname: "Dup", sovereign: "Dup", territory: "Dup")
+    assert_not eez.valid?
+    assert eez.errors[:mrgid].any?
+  end
+
+  test "requires geoname" do
+    eez = Eez.new(mrgid: 99999, sovereign: "Test", territory: "Test")
+    assert_not eez.valid?
+    assert eez.errors[:geoname].any?
+  end
+
+  test "requires sovereign" do
+    eez = Eez.new(mrgid: 99999, geoname: "Test", territory: "Test")
+    assert_not eez.valid?
+    assert eez.errors[:sovereign].any?
+  end
+
+  test "requires territory" do
+    eez = Eez.new(mrgid: 99999, geoname: "Test", sovereign: "Test")
+    assert_not eez.valid?
+    assert eez.errors[:territory].any?
+  end
+
+  test "has many locations" do
+    eez = eezs(:australian_gbr)
+    assert_includes eez.locations, locations(:great_barrier_reef)
+  end
+
+  test "has many publications through locations" do
+    eez = eezs(:australian_gbr)
+    assert eez.publications.count >= 0
+  end
+
+  test ".sovereigns returns sorted distinct list" do
+    sovereigns = Eez.sovereigns
+    assert_kind_of Array, sovereigns
+    assert_equal sovereigns, sovereigns.sort
+    assert_equal sovereigns.uniq, sovereigns
+  end
+
+  test ".by_sovereign filters by sovereign name" do
+    results = Eez.by_sovereign("Australia")
+    results.each { |eez| assert_equal "Australia", eez.sovereign }
+  end
+
+  test ".with_publications returns only EEZs with linked publications" do
+    results = Eez.with_publications
+    results.each do |eez|
+      assert eez.locations.joins(:publications).exists?
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Write Location EEZ association test**
+
+Add to `test/models/location_test.rb`:
+
+```ruby
+test "valid without eez" do
+  loc = Location.new(description: "Open Ocean", latitude: 10, longitude: 20)
+  assert loc.valid?
+end
+
+test "belongs to eez" do
+  loc = locations(:great_barrier_reef)
+  assert_equal eezs(:australian_gbr), loc.eez
+end
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `rails test test/models/eez_test.rb test/models/location_test.rb -v`
+Expected: FAIL — Eez model and fixtures don't exist yet.
+
+- [ ] **Step 4: Create fixtures**
+
+Create `test/fixtures/eezs.yml`:
+
+```yaml
+australian_gbr:
+  mrgid: 8440
+  geoname: "Australian Exclusive Economic Zone (Great Barrier Reef)"
+  sovereign: "Australia"
+  territory: "Great Barrier Reef"
+
+australian_coral_sea:
+  mrgid: 48188
+  geoname: "Australian Exclusive Economic Zone (Coral Sea)"
+  sovereign: "Australia"
+  territory: "Coral Sea"
+
+red_sea_egypt:
+  mrgid: 8441
+  geoname: "Egyptian Exclusive Economic Zone"
+  sovereign: "Egypt"
+  territory: "Egypt"
+
+unstudied_eez:
+  mrgid: 99998
+  geoname: "Unstudied Exclusive Economic Zone"
+  sovereign: "Unstudied Country"
+  territory: "Unstudied Territory"
+```
+
+- [ ] **Step 5: Create migrations**
+
+Generate and edit `db/migrate/TIMESTAMP_create_eezs.rb`:
+
+```ruby
+class CreateEezs < ActiveRecord::Migration[8.1]
+  def change
+    create_table :eezs do |t|
+      t.integer :mrgid, null: false
+      t.string :geoname, null: false
+      t.string :sovereign, null: false
+      t.string :territory, null: false
+      t.timestamps
+    end
+
+    add_index :eezs, :mrgid, unique: true
+    add_index :eezs, :sovereign
+  end
+end
+```
+
+Generate and edit `db/migrate/TIMESTAMP_add_eez_id_to_locations.rb`:
+
+```ruby
+class AddEezIdToLocations < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :locations, :eez, null: true, foreign_key: true
+  end
+end
+```
+
+Run: `rails db:migrate`
+
+- [ ] **Step 6: Create Eez model**
+
+Create `app/models/eez.rb`:
+
+```ruby
+class Eez < ApplicationRecord
+  has_many :locations
+  has_many :publications, -> { distinct }, through: :locations
+
+  validates :mrgid, presence: true, uniqueness: true
+  validates :geoname, presence: true
+  validates :sovereign, presence: true
+  validates :territory, presence: true
+
+  scope :by_sovereign, ->(name) { where(sovereign: name) }
+  scope :with_publications, -> {
+    joins(locations: :publications).distinct
+  }
+
+  def self.sovereigns
+    distinct.pluck(:sovereign).sort
+  end
+end
+```
+
+- [ ] **Step 7: Add belongs_to on Location**
+
+In `app/models/location.rb`, after the existing associations (line 22), add:
+
+```ruby
+belongs_to :eez, optional: true
+```
+
+- [ ] **Step 8: Update location fixtures to reference EEZ**
+
+Update `test/fixtures/locations.yml`:
+
+```yaml
+great_barrier_reef:
+  description: "Great Barrier Reef"
+  short_description: "GBR;Australia"
+  latitude: -18.2861
+  longitude: 147.7000
+  eez: australian_gbr
+
+red_sea:
+  description: "Red Sea"
+  short_description: "Red Sea;Middle East"
+  latitude: 27.2000
+  longitude: 34.8000
+  eez: red_sea_egypt
+```
+
+- [ ] **Step 9: Run tests to verify they pass**
+
+Run: `rails test test/models/eez_test.rb test/models/location_test.rb -v`
+Expected: ALL PASS
+
+- [ ] **Step 10: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS (no regressions)
+
+- [ ] **Step 11: Commit**
+
+```
+Add Eez model, migration, and Location association
+```
+
+---
+
+### Task 2: Seed Data and Rake Tasks
+
+**Files:**
+- Create: `db/seeds/eezs.csv` (extracted from VLIZ data)
+- Create: `lib/tasks/eez.rake`
+- Create: `test/tasks/eez_rake_test.rb`
+
+- [ ] **Step 1: Write rake task tests**
+
+Create `test/tasks/eez_rake_test.rb`:
+
+```ruby
+require 'test_helper'
+require 'rake'
+
+class EezRakeTest < ActiveSupport::TestCase
+  setup do
+    Mesophotic::Application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  test "eez:seed creates EEZ records from CSV" do
+    Eez.delete_all
+    Rake::Task['eez:seed'].reenable
+    Rake::Task['eez:seed'].invoke
+    assert Eez.count > 0, "Expected EEZ records to be created"
+    assert Eez.find_by(sovereign: "Australia").present?
+  end
+
+  test "eez:seed is idempotent" do
+    Rake::Task['eez:seed'].reenable
+    Rake::Task['eez:seed'].invoke
+    count_after_first = Eez.count
+    Rake::Task['eez:seed'].reenable
+    Rake::Task['eez:seed'].invoke
+    assert_equal count_after_first, Eez.count
+  end
+
+  test "eez:link_locations matches locations to EEZs" do
+    Rake::Task['eez:seed'].reenable
+    Rake::Task['eez:seed'].invoke
+    Rake::Task['eez:link_locations'].reenable
+    Rake::Task['eez:link_locations'].invoke
+    # Fixture locations should be matched if they exist in the CSV mapping
+    # At minimum, task should run without error
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `rails test test/tasks/eez_rake_test.rb -v`
+Expected: FAIL — rake tasks don't exist yet.
+
+- [ ] **Step 3: Prepare seed CSV**
+
+Extract the full VLIZ v12 EEZ dataset into `db/seeds/eezs.csv` with columns: `mrgid,geoname,sovereign,territory`. This requires downloading or extracting from the existing shapefile data in `docs/database/`. The CSV should contain ~280 rows covering all EEZs worldwide.
+
+For the initial implementation, create a minimal CSV from the existing `docs/database/mesophotic_org_EEZ_16112023.csv` mapping data, extracting unique sovereign/territory pairs. The full VLIZ dataset can be integrated later.
+
+Create `db/seeds/eezs.csv` by extracting unique EEZ entries. The file should have headers: `mrgid,geoname,sovereign,territory`.
+
+- [ ] **Step 4: Create rake tasks**
+
+Create `lib/tasks/eez.rake`:
+
+```ruby
+namespace :eez do
+  desc "Seed EEZ table from CSV"
+  task seed: :environment do
+    require 'csv'
+    csv_path = Rails.root.join('db/seeds/eezs.csv')
+    abort "EEZ seed CSV not found at #{csv_path}" unless File.exist?(csv_path)
+
+    count = 0
+    CSV.foreach(csv_path, headers: true) do |row|
+      Eez.find_or_create_by!(mrgid: row['mrgid'].to_i) do |eez|
+        eez.geoname = row['geoname']
+        eez.sovereign = row['sovereign']
+        eez.territory = row['territory']
+        count += 1
+      end
+    end
+    puts "Seeded #{count} new EEZ records (#{Eez.count} total)"
+  end
+
+  desc "Link existing locations to EEZs using mapping CSV"
+  task link_locations: :environment do
+    require 'csv'
+    csv_path = Rails.root.join('docs/database/mesophotic_org_EEZ_16112023.csv')
+    abort "Location mapping CSV not found at #{csv_path}" unless File.exist?(csv_path)
+
+    matched = 0
+    unmatched = []
+    CSV.foreach(csv_path, headers: true) do |row|
+      location = Location.find_by(description: row['Description'])
+      next unless location
+
+      sovereign = row['SOVEREIGN1']&.strip
+      territory = row['TERRITORY1']&.strip
+      eez = Eez.find_by(sovereign: sovereign, territory: territory)
+
+      if eez
+        location.update!(eez: eez)
+        matched += 1
+      else
+        unmatched << "#{location.description} -> #{sovereign} / #{territory}"
+      end
+    end
+    puts "Linked #{matched} locations to EEZs"
+    if unmatched.any?
+      puts "Unmatched (#{unmatched.count}):"
+      unmatched.each { |u| puts "  #{u}" }
+    end
+  end
+end
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `rails test test/tasks/eez_rake_test.rb -v`
+Expected: PASS (at least seed and idempotency tests)
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```
+Add EEZ seed data and rake tasks
+```
+
+---
+
+### Task 3: EEZ Controller and Routes
+
+**Files:**
+- Create: `app/controllers/eezs_controller.rb`
+- Modify: `config/routes.rb:75` (add eez routes)
+- Create: `test/controllers/eezs_controller_test.rb`
+
+- [ ] **Step 1: Write controller tests**
+
+Create `test/controllers/eezs_controller_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class EezsControllerTest < ActionDispatch::IntegrationTest
+  test "index renders successfully" do
+    get eezs_path
+    assert_response :success
+  end
+
+  test "index groups by sovereign" do
+    get eezs_path
+    assert_match "Australia", response.body
+  end
+
+  test "show renders for valid EEZ" do
+    eez = eezs(:australian_gbr)
+    get eez_path(eez)
+    assert_response :success
+    assert_match eez.territory, response.body
+  end
+
+  test "show displays sovereign" do
+    eez = eezs(:australian_gbr)
+    get eez_path(eez)
+    assert_match eez.sovereign, response.body
+  end
+
+  test "show 404 for invalid EEZ" do
+    get eez_path(id: 999999)
+    assert_response :not_found
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `rails test test/controllers/eezs_controller_test.rb -v`
+Expected: FAIL — controller and routes don't exist.
+
+- [ ] **Step 3: Add routes**
+
+In `config/routes.rb`, after line 75 (`resources :locations, except: :show`), add:
+
+```ruby
+resources :eezs, only: [:index, :show]
+```
+
+- [ ] **Step 4: Create controller**
+
+Create `app/controllers/eezs_controller.rb`:
+
+```ruby
+class EezsController < ApplicationController
+  def index
+    @studied = Eez.with_publications
+      .select("eezs.*, COUNT(DISTINCT publications.id) AS publications_count")
+      .joins(locations: :publications)
+      .group("eezs.id")
+      .order(:sovereign, :territory)
+      .group_by(&:sovereign)
+
+    @unstudied = Eez.where.not(id: Eez.with_publications)
+      .order(:sovereign, :territory)
+      .group_by(&:sovereign)
+  end
+
+  def show
+    @eez = Eez.find_by(id: params[:id])
+    return head(:not_found) unless @eez
+
+    @locations = @eez.locations
+      .left_joins(:publications)
+      .select("locations.*, COUNT(publications.id) AS publications_count")
+      .group("locations.id")
+      .order(Arel.sql("COUNT(publications.id) DESC"))
+  end
+end
+```
+
+- [ ] **Step 5: Create index view**
+
+Create `app/views/eezs/index.html.erb` — sovereign-first hierarchy with map. (Full ERB in implementation — uses collapsible Bootstrap accordion pattern grouped by sovereign, Tom Select search, and Turbo Frame world map with colored markers.)
+
+- [ ] **Step 6: Create show view**
+
+Create `app/views/eezs/show.html.erb` — territory detail page with locations list and map. (Full ERB in implementation — header with territory/sovereign, MRGID link to marineregions.org, locations list with publication counts, Turbo Frame map.)
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `rails test test/controllers/eezs_controller_test.rb -v`
+Expected: ALL PASS
+
+- [ ] **Step 8: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 9: Commit**
+
+```
+Add EEZ index and show pages with sovereign hierarchy
+```
+
+---
+
+### Task 4: Location Form EEZ Dropdown
+
+**Files:**
+- Modify: `app/views/locations/_form.html.erb` (add EEZ dropdown)
+- Modify: `app/controllers/locations_controller.rb:68` (add `:eez_id` to strong params)
+- Modify: `test/controllers/locations_controller_test.rb` (add EEZ param tests)
+
+- [ ] **Step 1: Write tests for EEZ dropdown and params**
+
+Add to `test/controllers/locations_controller_test.rb`:
+
+```ruby
+test "new form has EEZ dropdown" do
+  sign_in users(:editor_user)
+  get new_location_path
+  assert_select 'select[name="location[eez_id]"]'
+end
+
+test "edit form has EEZ dropdown" do
+  sign_in users(:editor_user)
+  get edit_location_path(locations(:great_barrier_reef))
+  assert_select 'select[name="location[eez_id]"]'
+end
+
+test "create with eez_id saves association" do
+  sign_in users(:editor_user)
+  eez = eezs(:australian_gbr)
+  post locations_path, params: { location: { description: "New Reef", latitude: -15.5, longitude: 145.8, eez_id: eez.id } }
+  assert_equal eez, Location.last.eez
+end
+
+test "update with eez_id saves association" do
+  sign_in users(:editor_user)
+  loc = locations(:great_barrier_reef)
+  new_eez = eezs(:australian_coral_sea)
+  patch location_path(loc), params: { location: { eez_id: new_eez.id } }
+  assert_equal new_eez, loc.reload.eez
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `rails test test/controllers/locations_controller_test.rb -v`
+Expected: FAIL — no dropdown in form, `eez_id` not permitted.
+
+- [ ] **Step 3: Add EEZ dropdown to form**
+
+In `app/views/locations/_form.html.erb`, add a new field group after the longitude field (before the publication count warning):
+
+```erb
+<div class="mb-3">
+  <%= f.label :eez_id, "EEZ", class: "required" %><br>
+  <%= f.select :eez_id,
+      options_for_select(
+        Eez.order(:sovereign, :territory).map { |e| ["#{e.territory} (#{e.sovereign})", e.id] },
+        location.eez_id
+      ),
+      { include_blank: "Select EEZ..." },
+      { class: "form-select", "data-tom-select" => "" } %>
+</div>
+```
+
+Note: Remove the `class: "required"` from the label — EEZ is optional per spec. Use just `f.label :eez_id, "EEZ"`.
+
+- [ ] **Step 4: Add `:eez_id` to strong params**
+
+In `app/controllers/locations_controller.rb`, change line 68:
+
+```ruby
+def location_params
+  params.require(:location).permit(:description, :latitude, :longitude, :eez_id)
+end
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `rails test test/controllers/locations_controller_test.rb -v`
+Expected: ALL PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```
+Add EEZ dropdown to location form with Tom Select
+```
+
+---
+
+### Task 5: Location Pages EEZ Metadata Display
+
+**Files:**
+- Modify: `app/views/summary/show.html.erb` or location summary view (show EEZ metadata)
+- Modify: `test/controllers/eezs_controller_test.rb` (or location display tests)
+
+The locations don't have a dedicated show page — they use the summary controller (`/:model/:id`). Check `app/views/summary/show.html.erb` and the summary controller to understand how location details are displayed, then add EEZ territory and sovereign as metadata linked to the EEZ show page.
+
+- [ ] **Step 1: Find where location details are displayed**
+
+Read `app/controllers/summary_controller.rb` and `app/views/summary/show.html.erb` to understand the location detail view. Add EEZ info after existing metadata.
+
+- [ ] **Step 2: Add EEZ metadata to location detail view**
+
+Add to the location summary display:
+
+```erb
+<% if @record.respond_to?(:eez) && @record.eez.present? %>
+  <p><strong>EEZ:</strong> <%= link_to "#{@record.eez.territory} (#{@record.eez.sovereign})", eez_path(@record.eez) %></p>
+<% end %>
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```
+Show EEZ metadata on location detail pages
+```
+
+---
+
+### Task 6: Publication Search Filter by Sovereign
+
+**Files:**
+- Modify: `app/models/publication.rb:145-157` (add `by_sovereign` to `base_search`)
+- Modify: `app/models/publication.rb` (add `publication_sovereigns` class method)
+- Modify: `app/views/publications/_search_field.html.erb:82-90` (add EEZ filter)
+- Create: `test/models/publication_eez_test.rb`
+
+- [ ] **Step 1: Write Publication EEZ scope tests**
+
+Create `test/models/publication_eez_test.rb`:
+
+```ruby
+require 'test_helper'
+
+class PublicationEezTest < ActiveSupport::TestCase
+  test ".by_sovereign returns publications in sovereign's EEZs" do
+    results = Publication.by_sovereign(["Australia"])
+    results.each do |pub|
+      sovereigns = pub.locations.filter_map { |l| l.eez&.sovereign }
+      assert_includes sovereigns, "Australia"
+    end
+  end
+
+  test ".by_sovereign with nil returns all" do
+    assert_equal Publication.all.count, Publication.by_sovereign(nil).count
+  end
+
+  test ".publication_sovereigns returns sorted unique list" do
+    sovereigns = Publication.publication_sovereigns
+    assert_kind_of Array, sovereigns
+    assert_equal sovereigns, sovereigns.sort
+    assert_equal sovereigns.uniq, sovereigns
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `rails test test/models/publication_eez_test.rb -v`
+Expected: FAIL — scope and method don't exist.
+
+- [ ] **Step 3: Add `by_sovereign` scope and `publication_sovereigns` method**
+
+In `app/models/publication.rb`, add after the dynamic scopes block (after line 169):
+
+```ruby
+scope :by_sovereign, ->(params) {
+  if params.present?
+    joins("INNER JOIN locations_publications ON publications.id = locations_publications.publication_id")
+    .joins("INNER JOIN locations ON locations.id = locations_publications.location_id")
+    .joins("INNER JOIN eezs ON eezs.id = locations.eez_id")
+    .where("eezs.sovereign IN (?)", params)
+  else
+    all
+  end
+}
+```
+
+Add class method (near the other `publication_*` methods):
+
+```ruby
+def self.publication_sovereigns
+  Eez.joins(locations: :publications)
+    .distinct
+    .pluck(:sovereign)
+    .sort
+end
+```
+
+- [ ] **Step 4: Add `by_sovereign` to `base_search`**
+
+In `app/models/publication.rb`, in the `base_search` scope (around line 148-151), add:
+
+```ruby
+.by_sovereign(search_params["sovereigns"])
+```
+
+- [ ] **Step 5: Add EEZ filter to search UI**
+
+In `app/views/publications/_search_field.html.erb`, after the Locations/Focus Groups row (after line 90), add:
+
+```erb
+<div class="row">
+  <hr>
+  <div class="col-sm-6">
+    <%= search_param "EEZ / Country", Publication.publication_sovereigns, :sovereigns, params, true %>
+  </div>
+</div>
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `rails test test/models/publication_eez_test.rb -v`
+Expected: ALL PASS
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 8: Commit**
+
+```
+Add publication search filter by EEZ sovereign
+```
+
+---
+
+### Task 7: CSV Export with EEZ Columns
+
+**Files:**
+- Modify: `app/models/publication.rb` (csv_header, csv_row, csv_association_data)
+- Add test in: `test/models/publication_eez_test.rb`
+
+- [ ] **Step 1: Write CSV export test**
+
+Add to `test/models/publication_eez_test.rb`:
+
+```ruby
+test "csv_header includes EEZ columns" do
+  header = Publication.csv_header
+  assert_includes header, "eez_sovereign"
+  assert_includes header, "eez_territory"
+end
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `rails test test/models/publication_eez_test.rb -v`
+Expected: FAIL — columns not in header yet.
+
+- [ ] **Step 3: Add EEZ columns to CSV export**
+
+In `app/models/publication.rb`:
+
+Add to `csv_header` (after `"locations"` on line 417):
+
+```ruby
+"eez_sovereign",
+"eez_territory"
+```
+
+Add to `csv_association_data` (after locations block, before the return on line 329):
+
+```ruby
+eez_sovereigns = Location
+  .select("publications.id, GROUP_CONCAT(DISTINCT eezs.sovereign, '; ') AS sovereign_names")
+  .joins(:publications)
+  .left_joins(:eez)
+  .group("publications.id")
+  .reduce({}) { |result, a| result.update(a.id => a.sovereign_names) }
+eez_territories = Location
+  .select("publications.id, GROUP_CONCAT(DISTINCT eezs.territory, '; ') AS territory_names")
+  .joins(:publications)
+  .left_joins(:eez)
+  .group("publications.id")
+  .reduce({}) { |result, a| result.update(a.id => a.territory_names) }
+```
+
+Update the return to include the new variables:
+
+```ruby
+[validated, fields, focusgroups, platforms, locations, eez_sovereigns, eez_territories]
+```
+
+Update `csv_row` signature and body to accept and include the new data:
+
+```ruby
+def self.csv_row publication, validated, fields, focusgroups, platforms, locations, eez_sovereigns, eez_territories
+```
+
+Add at end of row array (after `locations[publication.id]`):
+
+```ruby
+eez_sovereigns[publication.id],
+eez_territories[publication.id],
+```
+
+Update all callers of `csv_row` and `csv_association_data` (in `csv_enumerator` around line 341) to destructure the new return values.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `rails test test/models/publication_eez_test.rb -v`
+Expected: ALL PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```
+Add EEZ sovereign and territory to publication CSV export
+```
+
+---
+
+### Task 8: Stats Chart — Publications by Country
+
+**Files:**
+- Modify: `app/controllers/stats_controller.rb` (add `world_sovereigns` action)
+- Create: `app/views/stats/_world_sovereigns.html.erb`
+- Modify: `app/views/stats/_world.html.erb` (add Turbo Frame for new chart)
+- Modify: `config/routes.rb` (add stats route)
+
+- [ ] **Step 1: Add route**
+
+In `config/routes.rb`, after line 69 (`get :world_locations, controller: :stats`), add:
+
+```ruby
+get :world_sovereigns, controller: :stats
+```
+
+- [ ] **Step 2: Add controller action**
+
+In `app/controllers/stats_controller.rb`, add `world_sovereigns` to the `before_action :load_publications_for_status` list (line 8), then add the action:
+
+```ruby
+def world_sovereigns
+  @sovereigns = Eez
+    .joins(locations: :publications)
+    .select("eezs.sovereign AS description, eezs.sovereign AS chart_description, COUNT(DISTINCT publications.id) AS publications_count")
+    .where("publications.id IN (SELECT id FROM (#{@publications.to_sql}))")
+    .group("eezs.sovereign")
+    .order(Arel.sql("COUNT(DISTINCT publications.id) DESC"))
+
+  render_in_turbo_frame("stats-world_sovereigns") { render_to_string partial: "world_sovereigns" }
+end
+```
+
+Note: We alias `sovereign` as `description` and `chart_description` so it works with the existing `format_for_chart` helper which expects those methods.
+
+- [ ] **Step 3: Create partial**
+
+Create `app/views/stats/_world_sovereigns.html.erb`:
+
+```erb
+<%= render partial: 'shared/stats_bar_graph',
+           locals: { title: 'Sovereigns_bar_graph',
+                     data: format_for_chart(@sovereigns, 25),
+                     height: 600,
+                     unit: 'Percentage' } %>
+<p>
+  Fig. 3d: <b>EEZ Sovereigns (top 25)</b><br>
+</p>
+```
+
+- [ ] **Step 4: Add Turbo Frame to stats world section**
+
+In `app/views/stats/_world.html.erb`, add after the world_locations Turbo Frame (after line 13):
+
+```erb
+<div class="col-sm-6" style="min-height: 600px;">
+  <%= turbo_frame_tag "stats-world_sovereigns", src: world_sovereigns_path(:status => @status, :year => @year), loading: :lazy %>
+</div>
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```
+Add Publications by Country stats chart
+```
+
+---
+
+### Task 9: EEZ Index Map with Colored Markers
+
+**Files:**
+- Modify: `app/assets/javascripts/charts.js` (add `map-colored` chart type)
+- Modify: `app/views/eezs/index.html.erb` (use colored map)
+- Modify: `app/controllers/eezs_controller.rb` (provide map data)
+
+- [ ] **Step 1: Add `map-colored` chart type to charts.js**
+
+In `app/assets/javascripts/charts.js`, add a new chart type in the `chartTypes` object:
+
+```javascript
+'map-colored': function(el) { mapColored(el); },
+```
+
+Add the `mapColored` function:
+
+```javascript
+function mapColored(el) {
+  var data = JSON.parse(el.dataset.values);
+  var config = baseOpts(el);
+  config.chart = { backgroundColor: 'rgba(255, 255, 255, 0)' };
+  config.mapNavigation = { enabled: true, buttonOptions: { verticalAlign: 'top' } };
+  config.exporting = { enabled: false };
+
+  // Group data by sovereign, assign deterministic colors
+  var palette = ['#058DC7', '#50B432', '#ED561B', '#DDDF00', '#24CBE5',
+                 '#64E572', '#FF9655', '#FFF263', '#6AF9C4', '#FF6B6B',
+                 '#C49C94', '#9EDAE5', '#DBDB8D', '#E377C2', '#7F7F7F'];
+  var groups = {};
+  data.forEach(function(point) {
+    if (!groups[point.sovereign]) groups[point.sovereign] = [];
+    groups[point.sovereign].push(point);
+  });
+
+  var series = [
+    { name: 'Countries', mapData: Highcharts.maps['custom/world-continents'], color: '#E0E0E0', enableMouseTracking: false }
+  ];
+
+  var sovereigns = Object.keys(groups).sort();
+  sovereigns.forEach(function(sov, i) {
+    series.push({
+      type: 'mapbubble',
+      name: sov,
+      data: groups[sov],
+      color: palette[i % palette.length],
+      maxSize: '12%',
+      dataLabels: { enabled: true, format: '{point.name}' },
+      cursor: 'pointer',
+      point: { events: { click: function() { if (this.options.url) window.location = this.options.url; } } }
+    });
+  });
+
+  config.legend = { enabled: true };
+  config.series = series;
+  Highcharts.mapChart(el, config);
+}
+```
+
+- [ ] **Step 2: Add map data to EEZ index controller**
+
+In `app/controllers/eezs_controller.rb`, in the `index` action, add:
+
+```ruby
+@map_data = Location.joins(:publications, :eez)
+  .select("locations.*, eezs.sovereign, COUNT(DISTINCT publications.id) AS pub_count")
+  .group("locations.id")
+  .map { |l| { name: l.description, lat: l.latitude.to_f, lon: l.longitude.to_f, z: l.pub_count, sovereign: l.sovereign, url: summary_path(model: 'locations', id: l.id) } }
+```
+
+- [ ] **Step 3: Use colored map in index view**
+
+In `app/views/eezs/index.html.erb`, add the map div:
+
+```erb
+<div data-chart="map-colored"
+     data-values="<%= @map_data.to_json %>"
+     style="height: 400px;"></div>
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```
+Add colored map markers by sovereign to EEZ index
+```
+
+---
+
+### Task 10: Navigation and Final Integration
+
+**Files:**
+- Modify: `app/views/layouts/_navigation_links.html.erb` (add EEZ link to nav)
+- Modify: `app/models/publication.rb:458` (add `"sovereigns"` to `default_search_params`)
+- Run full test suite and verify everything works end-to-end.
+
+- [ ] **Step 1: Add EEZ to navigation**
+
+In `app/views/layouts/_navigation_links.html.erb`, uncomment or add an EEZ/Countries link in the nav bar (either as a standalone link or under the Categories dropdown). Follow the existing pattern:
+
+```erb
+<%= render partial: 'layouts/link',
+           locals: { path: eezs_path,
+                     title: 'Countries',
+                     icon: 'bi-globe-americas' } %>
+```
+
+- [ ] **Step 2: Add sovereigns to default search params**
+
+In `app/models/publication.rb`, in `default_search_params` method, add:
+
+```ruby
+"sovereigns" => nil,
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `rails test`
+Expected: ALL PASS
+
+- [ ] **Step 4: Manual smoke test**
+
+- Visit `/eezs` — verify sovereign hierarchy renders, map shows colored markers
+- Visit `/eezs/:id` — verify territory detail page
+- Visit `/locations/new` — verify EEZ dropdown appears
+- Visit `/publications` — verify EEZ/Country filter in advanced filters
+- Visit `/statistics/all/2023` — verify Publications by Country chart loads
+- Download CSV — verify `eez_sovereign` and `eez_territory` columns present
+
+- [ ] **Step 5: Commit**
+
+```
+Add EEZ navigation link and finalize integration
+```
+
+- [ ] **Step 6: Create PR**
+
+Create PR with title: "Add EEZ (Exclusive Economic Zone) data (fixes #153)"

--- a/docs/superpowers/specs/2026-04-12-eez-design.md
+++ b/docs/superpowers/specs/2026-04-12-eez-design.md
@@ -1,0 +1,170 @@
+# EEZ (Exclusive Economic Zone) Feature Design
+
+**GitHub Issue:** #153
+**Date:** 2026-04-12
+
+## Overview
+
+Add EEZ (Exclusive Economic Zone) data to mesophotic.org, enabling users to browse research by sovereign nation and territory, view EEZ metadata on locations, filter publications by country, and see EEZ-aware stats and maps.
+
+## Data Source
+
+The canonical source is the **VLIZ Marine Regions v12** dataset (~280 EEZ records worldwide). The project already has a prepared mapping CSV (`docs/database/mesophotic_org_EEZ_16112023.csv`) that links existing locations to their EEZ sovereign and territory.
+
+We store the `MRGID` (Marine Regions ID) per EEZ as a stable foreign key for future boundary polygon integration.
+
+## Data Model
+
+### Approach: Flat EEZ table with sovereign as virtual grouping
+
+A single `eezs` table. Sovereign is a string column — grouping/filtering is done via scopes. No separate sovereigns table (YAGNI — can be extracted later if sovereign-level metadata is needed).
+
+### `eezs` table
+
+| Column     | Type    | Notes                                                        |
+|------------|---------|--------------------------------------------------------------|
+| `id`       | integer | PK                                                           |
+| `mrgid`    | integer | VLIZ Marine Regions ID, unique, indexed                      |
+| `geoname`  | string  | Full EEZ name (e.g., "Australian Exclusive Economic Zone")   |
+| `sovereign`| string  | Sovereign nation (e.g., "Australia"), indexed                 |
+| `territory`| string  | Territory name (e.g., "Coral Sea")                           |
+| timestamps |         | created_at, updated_at                                       |
+
+### `locations` table change
+
+- Add `eez_id` (integer, nullable foreign key, indexed)
+
+### Associations
+
+```ruby
+# Eez
+has_many :locations
+has_many :publications, -> { distinct }, through: :locations
+
+# Location
+belongs_to :eez, optional: true
+```
+
+`optional: true` because existing locations won't all be mapped immediately, and some research locations (e.g., international waters) may not fall in any EEZ.
+
+### Scopes on Eez
+
+- `Eez.sovereigns` — `distinct.pluck(:sovereign).sort`
+- `Eez.by_sovereign(name)` — `where(sovereign: name)`
+- `Eez.with_publications` — only EEZs that have locations with publications
+
+## UI
+
+### 1. EEZ Index Page (`/eezs`)
+
+**Layout:** Sovereign-first hierarchy list on the left, world map on the right.
+
+**List panel:**
+- Grouped by sovereign, sorted alphabetically
+- Each sovereign is a collapsible header showing: name + total publication count across all its territories
+- Under each sovereign, territories listed with their own publication count
+- Sovereigns with no linked publications shown in a muted/collapsed "Unstudied" section at the bottom (full dataset is seeded)
+- Tom Select search at the top to jump to a sovereign or territory
+
+**Map panel:**
+- World map with location markers color-coded by sovereign + legend
+- Clicking a marker links to the location page
+
+### 2. EEZ Show Page (`/eezs/:id`)
+
+- Header: territory name, sovereign shown as subtitle/badge
+- MRGID linking out to the Marine Regions page for that EEZ
+- List of locations within this EEZ, each with publication count
+- Map zoomed to show just this EEZ's locations with markers
+- Stats summary: total publications, top species/fields studied
+
+### 3. Location Pages
+
+- Location detail/edit pages show EEZ territory and sovereign as metadata, e.g., "EEZ: Coral Sea (Australia)" — linked to the EEZ show page
+- Admin edit form: Tom Select dropdown for EEZ assignment (searchable by territory and sovereign)
+- Admin new form: same dropdown
+
+### 4. Publication Integration
+
+- CSV export: add `eez_sovereign` and `eez_territory` columns
+- Publication search/filters: add "EEZ / Country" to advanced filters — Tom Select multi-select dropdown listing sovereigns with territory count, e.g., "Australia (7 territories)"
+- Filtering by sovereign returns publications linked to any location in any of that sovereign's EEZs
+- Implemented as a scope on Publication: `.by_sovereign(names)` — joins through locations -> eezs
+
+### 5. Stats Page
+
+- New "Publications by Country" horizontal bar chart (top 25 sovereigns)
+- Same Highcharts pattern as existing stats charts
+- Query: join publications -> locations -> eezs, group by sovereign, count distinct publications
+
+### 6. Maps
+
+- EEZ index map: location markers color-coded by sovereign + legend. Colors assigned via a deterministic palette (consistent color per sovereign across page loads).
+- EEZ show page map: zoomed to that EEZ's locations
+- Locations index map: unchanged
+- Map boundary overlays: **deferred** to a future phase. MRGID stored now for future linking.
+
+**Routing:** `resources :eezs, only: [:index, :show]` — no public create/edit. Admin edits through RailsAdmin.
+
+**Strong params:** Location `location_params` adds `:eez_id`.
+
+## Seed Data & Admin
+
+### Seed data
+
+- Full VLIZ Marine Regions v12 dataset (~280 EEZ records)
+- Delivered as a CSV seed file in `db/seeds/`
+- Idempotent — upsert by MRGID, safe to re-run
+
+### Linking existing locations
+
+- Use prepared `mesophotic_org_EEZ_16112023.csv` to match existing locations by description -> set `eez_id`
+- Rake tasks: `rake eez:seed` (load EEZ table) and `rake eez:link_locations` (match locations to EEZs)
+- Unmatched locations get `eez_id: nil` — admin can assign manually
+
+### Admin workflow
+
+- EEZ records managed through RailsAdmin (reference data, no custom CRUD)
+- Location forms get a Tom Select dropdown for EEZ assignment
+
+## Testing
+
+### Model tests (Eez)
+
+- Validations: requires mrgid (unique), geoname, sovereign, territory
+- Associations: `has_many :locations`, `has_many :publications, through: :locations`
+- Scopes: `.sovereigns`, `.by_sovereign(name)`, `.with_publications`
+
+### Model tests (Location)
+
+- `belongs_to :eez, optional: true` — location valid without EEZ
+- `location.eez` returns associated EEZ
+
+### Controller tests (EezsController)
+
+- Index renders successfully, groups by sovereign
+- Show renders for a valid EEZ, shows linked locations
+- 404 for invalid EEZ id
+
+### Controller tests (LocationsController)
+
+- Create/update with `eez_id` param saves association
+- Form renders EEZ dropdown
+
+### Integration/scope tests
+
+- `Publication.by_sovereign("Australia")` returns correct publications
+- EEZ with no locations returns zero publication count
+- CSV export includes EEZ columns
+
+### Seed task tests
+
+- `eez:seed` creates expected number of records
+- `eez:link_locations` matches locations correctly
+- Re-running seed is idempotent
+
+## Deferred / Future Work
+
+- **Map boundary overlays:** EEZ boundary polygons from VLIZ shapefile or WMS service. MRGID stored now as the linking key.
+- **Auto-suggest EEZ from coordinates:** Point-in-polygon lookup against boundary data when admin enters lat/lon. Requires boundary data.
+- **Sovereign table extraction:** If sovereign-level metadata (ISO codes, flags, UN codes) is needed, extract from string column to its own table.

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -1,15 +1,15 @@
-ACCESS_KEY_ID = Rails.application.credentials.dig(:aws, :access_key_id)
-SECRET_ACCESS_KEY = Rails.application.credentials.dig(:aws, :secret_access_key)
-BUCKET = Rails.application.credentials.dig(:aws, :bucket)
+ACCESS_KEY_ID = Rails.application.credentials.dig(:aws, :access_key_id) unless defined?(ACCESS_KEY_ID)
+SECRET_ACCESS_KEY = Rails.application.credentials.dig(:aws, :secret_access_key) unless defined?(SECRET_ACCESS_KEY)
+BUCKET = Rails.application.credentials.dig(:aws, :bucket) unless defined?(BUCKET)
 
-DATABASE_NAME = "production.sqlite3"
-DATABASE_DIR = Rails.root.join("db")
-DATABASE_PATH = "#{DATABASE_DIR}/#{DATABASE_NAME}"
-STORAGE_DIR = Rails.root.join("storage")
+DATABASE_NAME = "production.sqlite3" unless defined?(DATABASE_NAME)
+DATABASE_DIR = Rails.root.join("db") unless defined?(DATABASE_DIR)
+DATABASE_PATH = "#{DATABASE_DIR}/#{DATABASE_NAME}" unless defined?(DATABASE_PATH)
+STORAGE_DIR = Rails.root.join("storage") unless defined?(STORAGE_DIR)
 
-YEAR = `TZ=Australia/Brisbane date "+%Y"`.chomp
-COMPRESSED_DATABASE_NAME = `TZ=Australia/Brisbane date "+%Y%m%d-#{DATABASE_NAME}.xz"`.chomp
-COMPRESSED_DATABASE_PATH = "#{DATABASE_DIR}/#{COMPRESSED_DATABASE_NAME}"
+YEAR = `TZ=Australia/Brisbane date "+%Y"`.chomp unless defined?(YEAR)
+COMPRESSED_DATABASE_NAME = `TZ=Australia/Brisbane date "+%Y%m%d-#{DATABASE_NAME}.xz"`.chomp unless defined?(COMPRESSED_DATABASE_NAME)
+COMPRESSED_DATABASE_PATH = "#{DATABASE_DIR}/#{COMPRESSED_DATABASE_NAME}" unless defined?(COMPRESSED_DATABASE_PATH)
 
 namespace :backup do
   desc "Backup database and storage to AWS S3"

--- a/lib/tasks/eez.rake
+++ b/lib/tasks/eez.rake
@@ -23,6 +23,75 @@ namespace :eez do
     csv_path = Rails.root.join('docs/database/mesophotic_org_EEZ_16112023.csv')
     abort "Location mapping CSV not found at #{csv_path}" unless File.exist?(csv_path)
 
+    # Name mappings from the project's mapping CSV to VLIZ sovereign/territory names
+    sovereign_aliases = {
+      "USA" => "United States",
+      "Comores" => "Comoros",
+      "South Korea" => "Republic of Korea",
+      "High Seas" => nil
+    }
+
+    # Map from mapping CSV territory to VLIZ territory (or :sovereign to use sovereign's main EEZ)
+    territory_map = {
+      # Australia sub-regions → main Australian EEZ
+      ["Australia", "Coral Sea"] => ["Australia", "Australia"],
+      ["Australia", "Great Barrier Reef"] => ["Australia", "Australia"],
+      ["Australia", "Northern Australia"] => ["Australia", "Australia"],
+      ["Australia", "Southeastern Australia"] => ["Australia", "Australia"],
+      ["Australia", "Scott Reef"] => ["Australia", "Australia"],
+      ["Australia", "Western Australia"] => ["Australia", "Australia"],
+      # Brazil sub-regions
+      ["Brazil", "Eastern Brazil"] => ["Brazil", "Brazil"],
+      ["Brazil", "Fernando Noronha"] => ["Brazil", "Brazil"],
+      ["Brazil", "St Peter and St Paul Archipelago"] => ["Brazil", "Brazil"],
+      ["Brazil", "Trindade and Martin Vaz"] => ["Brazil", "Trindade"],
+      # USA territories
+      ["USA", "American Samoa"] => ["United States", "American Samoa"],
+      ["USA", "Guam"] => ["United States", "Guam"],
+      ["USA", "Gulf of Mexico"] => ["United States", "United States"],
+      ["USA", "Hawaii"] => ["United States", "Hawaii"],
+      ["USA", "Johnston Atoll"] => ["United States", "Johnston Atoll"],
+      ["USA", "Mariana Islands"] => ["United States", "Northern Mariana Islands"],
+      ["USA", "Puerto Rico"] => ["United States", "Puerto Rico"],
+      ["USA", "Pulley Ridge"] => ["United States", "United States"],
+      ["USA", "US Virgin Islands"] => ["United States", "United States Virgin Islands"],
+      ["USA", "USA"] => ["United States", "United States"],
+      # UK territories
+      ["United Kingdom", "England"] => ["United Kingdom", "United Kingdom"],
+      ["United Kingdom", "Scotland"] => ["United Kingdom", "United Kingdom"],
+      ["United Kingdom", "Pitcairn Islands"] => ["United Kingdom", "Pitcairn"],
+      ["United Kingdom", "Turks and Caicos"] => ["United Kingdom", "Turks and Caicos Islands"],
+      # France territories
+      ["France", "La Perouse"] => ["France", "Réunion"],
+      ["France", "Reunion Islands"] => ["France", "Réunion"],
+      # India sub-regions
+      ["India", "Andaman and Nicobar Islands"] => ["India", "Andaman and Nicobar"],
+      ["India", "Bay of Bengal"] => ["India", "India"],
+      ["India", "Laccadive Sea"] => ["India", "India"],
+      # Japan sub-regions
+      ["Japan", "Ogasawara Islands"] => ["Japan", "Japan"],
+      ["Japan", "Ryukyu Islands"] => ["Japan", "Japan"],
+      # Mexico sub-regions
+      ["Mexico", "Baja California"] => ["Mexico", "Mexico"],
+      ["Mexico", "Gulf of Mexico"] => ["Mexico", "Mexico"],
+      # Micronesia
+      ["Micronesia", "Caroline Islands"] => ["Micronesia", "Micronesia"],
+      ["Micronesia", "Chuuk atoll"] => ["Micronesia", "Micronesia"],
+      # Other specific mappings
+      ["Chile", "Salas y Gomez Nazca Ridge"] => ["Chile", "Chile"],
+      ["Comores", "Comoros"] => ["Comores", "Comores"],
+      ["Ecuador", "Galapagos Islands"] => ["Ecuador", "Galapagos"],
+      ["Honduras", "Bay Islands"] => ["Honduras", "Honduras"],
+      ["Kiribati", "Kiribati"] => ["Kiribati", "Gilbert Islands"],
+      ["Mauritius", "Chagos Archipelago"] => ["Republic of Mauritius", "Chagos Archipelago"],
+      ["Mauritius", "Mauritius"] => ["Republic of Mauritius", "Republic of Mauritius"],
+      ["Netherlands", "Curacao"] => ["Netherlands", "Curaçao"],
+      ["Netherlands", "Saba Bank"] => ["Netherlands", "Bonaire"],
+      ["Saint Vincent and the Grenadines", "St Vincent"] => ["Saint Vincent and the Grenadines", "Saint Vincent and the Grenadines"],
+      ["South Korea", "Jejudo Island"] => ["South Korea", "South Korea"],
+      ["High Seas", "Saya de Malha Bank"] => nil
+    }
+
     matched = 0
     unmatched = []
     CSV.foreach(csv_path, headers: true) do |row|
@@ -31,6 +100,20 @@ namespace :eez do
 
       sovereign = row['SOVEREIGN1']&.strip
       territory = row['TERRITORY1']&.strip
+
+      # Apply territory mapping first (most specific)
+      if territory_map.key?([sovereign, territory])
+        mapping = territory_map[[sovereign, territory]]
+        if mapping.nil?
+          next # Skip unmappable entries (e.g., High Seas)
+        end
+        sovereign, territory = mapping
+      else
+        # Apply sovereign alias
+        sovereign = sovereign_aliases.fetch(sovereign, sovereign)
+        next if sovereign.nil? # Skip entries with no sovereign mapping
+      end
+
       eez = Eez.find_by(sovereign: sovereign, territory: territory)
 
       if eez

--- a/lib/tasks/eez.rake
+++ b/lib/tasks/eez.rake
@@ -1,0 +1,49 @@
+namespace :eez do
+  desc "Seed EEZ table from CSV"
+  task seed: :environment do
+    require 'csv'
+    csv_path = Rails.root.join('db/seeds/eezs.csv')
+    abort "EEZ seed CSV not found at #{csv_path}" unless File.exist?(csv_path)
+
+    count = 0
+    CSV.foreach(csv_path, headers: true) do |row|
+      Eez.find_or_create_by!(mrgid: row['mrgid'].to_i) do |eez|
+        eez.geoname = row['geoname']
+        eez.sovereign = row['sovereign']
+        eez.territory = row['territory']
+        count += 1
+      end
+    end
+    puts "Seeded #{count} new EEZ records (#{Eez.count} total)"
+  end
+
+  desc "Link existing locations to EEZs using mapping CSV"
+  task link_locations: :environment do
+    require 'csv'
+    csv_path = Rails.root.join('docs/database/mesophotic_org_EEZ_16112023.csv')
+    abort "Location mapping CSV not found at #{csv_path}" unless File.exist?(csv_path)
+
+    matched = 0
+    unmatched = []
+    CSV.foreach(csv_path, headers: true) do |row|
+      location = Location.find_by(description: row['Description'])
+      next unless location
+
+      sovereign = row['SOVEREIGN1']&.strip
+      territory = row['TERRITORY1']&.strip
+      eez = Eez.find_by(sovereign: sovereign, territory: territory)
+
+      if eez
+        location.update!(eez: eez)
+        matched += 1
+      else
+        unmatched << "#{location.description} -> #{sovereign} / #{territory}"
+      end
+    end
+    puts "Linked #{matched} locations to EEZs"
+    if unmatched.any?
+      puts "Unmatched (#{unmatched.count}):"
+      unmatched.each { |u| puts "  #{u}" }
+    end
+  end
+end

--- a/test/controllers/eezs_controller_test.rb
+++ b/test/controllers/eezs_controller_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class EezsControllerTest < ActionDispatch::IntegrationTest
+  test "index renders successfully" do
+    get eezs_path
+    assert_response :success
+  end
+
+  test "index groups by sovereign" do
+    get eezs_path
+    assert_match "Australia", response.body
+  end
+
+  test "show renders for valid EEZ" do
+    eez = eezs(:australian_gbr)
+    get eez_path(eez)
+    assert_response :success
+    assert_match eez.territory, response.body
+  end
+
+  test "show displays sovereign" do
+    eez = eezs(:australian_gbr)
+    get eez_path(eez)
+    assert_match eez.sovereign, response.body
+  end
+
+  test "show 404 for invalid EEZ" do
+    get eez_path(id: 999999)
+    assert_response :not_found
+  end
+end

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -146,4 +146,33 @@ class LocationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_not_equal "", loc.reload.description
   end
+
+  # --- EEZ dropdown ---
+
+  test "new form has EEZ dropdown" do
+    sign_in users(:editor_user)
+    get new_location_path
+    assert_select 'select[name="location[eez_id]"]'
+  end
+
+  test "edit form has EEZ dropdown" do
+    sign_in users(:editor_user)
+    get edit_location_path(locations(:great_barrier_reef))
+    assert_select 'select[name="location[eez_id]"]'
+  end
+
+  test "create with eez_id saves association" do
+    sign_in users(:editor_user)
+    eez = eezs(:australian_gbr)
+    post locations_path, params: { location: { description: "New Reef", latitude: -15.5, longitude: 145.8, eez_id: eez.id } }
+    assert_equal eez, Location.last.eez
+  end
+
+  test "update with eez_id saves association" do
+    sign_in users(:editor_user)
+    loc = locations(:great_barrier_reef)
+    new_eez = eezs(:australian_coral_sea)
+    patch location_path(loc), params: { location: { eez_id: new_eez.id } }
+    assert_equal new_eez, loc.reload.eez
+  end
 end

--- a/test/fixtures/eezs.yml
+++ b/test/fixtures/eezs.yml
@@ -1,0 +1,23 @@
+australian_gbr:
+  mrgid: 8440
+  geoname: "Australian Exclusive Economic Zone (Great Barrier Reef)"
+  sovereign: "Australia"
+  territory: "Great Barrier Reef"
+
+australian_coral_sea:
+  mrgid: 48188
+  geoname: "Australian Exclusive Economic Zone (Coral Sea)"
+  sovereign: "Australia"
+  territory: "Coral Sea"
+
+red_sea_egypt:
+  mrgid: 8441
+  geoname: "Egyptian Exclusive Economic Zone"
+  sovereign: "Egypt"
+  territory: "Egypt"
+
+unstudied_eez:
+  mrgid: 99998
+  geoname: "Unstudied Exclusive Economic Zone"
+  sovereign: "Unstudied Country"
+  territory: "Unstudied Territory"

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -3,9 +3,11 @@ great_barrier_reef:
   short_description: "GBR;Australia"
   latitude: -18.2861
   longitude: 147.7000
+  eez: australian_gbr
 
 red_sea:
   description: "Red Sea"
   short_description: "Red Sea;Middle East"
   latitude: 27.2000
   longitude: 34.8000
+  eez: red_sea_egypt

--- a/test/models/eez_test.rb
+++ b/test/models/eez_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+class EezTest < ActiveSupport::TestCase
+  test "valid with all required fields" do
+    eez = Eez.new(mrgid: 99999, geoname: "Test EEZ", sovereign: "Testland", territory: "Test Territory")
+    assert eez.valid?
+  end
+
+  test "requires mrgid" do
+    eez = Eez.new(geoname: "Test", sovereign: "Test", territory: "Test")
+    assert_not eez.valid?
+    assert eez.errors[:mrgid].any?
+  end
+
+  test "requires unique mrgid" do
+    eez = Eez.new(mrgid: eezs(:australian_gbr).mrgid, geoname: "Dup", sovereign: "Dup", territory: "Dup")
+    assert_not eez.valid?
+    assert eez.errors[:mrgid].any?
+  end
+
+  test "requires geoname" do
+    eez = Eez.new(mrgid: 99999, sovereign: "Test", territory: "Test")
+    assert_not eez.valid?
+    assert eez.errors[:geoname].any?
+  end
+
+  test "requires sovereign" do
+    eez = Eez.new(mrgid: 99999, geoname: "Test", territory: "Test")
+    assert_not eez.valid?
+    assert eez.errors[:sovereign].any?
+  end
+
+  test "requires territory" do
+    eez = Eez.new(mrgid: 99999, geoname: "Test", sovereign: "Test")
+    assert_not eez.valid?
+    assert eez.errors[:territory].any?
+  end
+
+  test "has many locations" do
+    eez = eezs(:australian_gbr)
+    assert_includes eez.locations, locations(:great_barrier_reef)
+  end
+
+  test "has many publications through locations" do
+    eez = eezs(:australian_gbr)
+    assert eez.publications.count >= 0
+  end
+
+  test ".sovereigns returns sorted distinct list" do
+    sovereigns = Eez.sovereigns
+    assert_kind_of Array, sovereigns
+    assert_equal sovereigns, sovereigns.sort
+    assert_equal sovereigns.uniq, sovereigns
+  end
+
+  test ".by_sovereign filters by sovereign name" do
+    results = Eez.by_sovereign("Australia")
+    results.each { |eez| assert_equal "Australia", eez.sovereign }
+  end
+
+  test ".with_publications returns only EEZs with linked publications" do
+    results = Eez.with_publications
+    results.each do |eez|
+      assert eez.locations.joins(:publications).exists?
+    end
+  end
+end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -42,4 +42,14 @@ class LocationTest < ActiveSupport::TestCase
     loc = locations(:great_barrier_reef)
     assert_includes loc.sites, sites(:osprey_reef)
   end
+
+  test "valid without eez" do
+    loc = Location.new(description: "Open Ocean", latitude: 10, longitude: 20)
+    assert loc.valid?
+  end
+
+  test "belongs to eez" do
+    loc = locations(:great_barrier_reef)
+    assert_equal eezs(:australian_gbr), loc.eez
+  end
 end

--- a/test/models/publication_eez_test.rb
+++ b/test/models/publication_eez_test.rb
@@ -19,4 +19,10 @@ class PublicationEezTest < ActiveSupport::TestCase
     assert_equal sovereigns, sovereigns.sort
     assert_equal sovereigns.uniq, sovereigns
   end
+
+  test "csv_header includes EEZ columns" do
+    header = Publication.csv_header
+    assert_includes header, "eez_sovereign"
+    assert_includes header, "eez_territory"
+  end
 end

--- a/test/models/publication_eez_test.rb
+++ b/test/models/publication_eez_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class PublicationEezTest < ActiveSupport::TestCase
+  test ".by_sovereign returns publications in sovereign's EEZs" do
+    results = Publication.by_sovereign(["Australia"])
+    results.each do |pub|
+      sovereigns = pub.locations.filter_map { |l| l.eez&.sovereign }
+      assert_includes sovereigns, "Australia"
+    end
+  end
+
+  test ".by_sovereign with nil returns all" do
+    assert_equal Publication.all.count, Publication.by_sovereign(nil).count
+  end
+
+  test ".publication_sovereigns returns sorted unique list" do
+    sovereigns = Publication.publication_sovereigns
+    assert_kind_of Array, sovereigns
+    assert_equal sovereigns, sovereigns.sort
+    assert_equal sovereigns.uniq, sovereigns
+  end
+end

--- a/test/tasks/eez_rake_test.rb
+++ b/test/tasks/eez_rake_test.rb
@@ -3,32 +3,57 @@ require 'rake'
 
 class EezRakeTest < ActiveSupport::TestCase
   setup do
-    Mesophotic::Application.load_tasks if Rake::Task.tasks.empty?
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  test "seed CSV exists with correct headers and sufficient records" do
+    require 'csv'
+    csv_path = Rails.root.join('db/seeds/eezs.csv')
+    assert File.exist?(csv_path)
+
+    table = CSV.read(csv_path, headers: true)
+    %w[mrgid geoname sovereign territory].each do |col|
+      assert_includes table.headers, col
+    end
+    assert table.length > 200, "Expected at least 200 EEZ records, got #{table.length}"
   end
 
   test "eez:seed creates EEZ records from CSV" do
     Location.where.not(eez_id: nil).update_all(eez_id: nil)
     Eez.delete_all
+
     Rake::Task['eez:seed'].reenable
-    Rake::Task['eez:seed'].invoke
-    assert Eez.count > 0, "Expected EEZ records to be created"
+    quietly { Rake::Task['eez:seed'].invoke }
+
+    assert Eez.count > 200
     assert Eez.find_by(sovereign: "Australia").present?
   end
 
   test "eez:seed is idempotent" do
     Rake::Task['eez:seed'].reenable
-    Rake::Task['eez:seed'].invoke
+    quietly { Rake::Task['eez:seed'].invoke }
     count_after_first = Eez.count
+
     Rake::Task['eez:seed'].reenable
-    Rake::Task['eez:seed'].invoke
+    quietly { Rake::Task['eez:seed'].invoke }
     assert_equal count_after_first, Eez.count
   end
 
-  test "eez:link_locations matches locations to EEZs" do
+  test "eez:link_locations runs without error" do
     Rake::Task['eez:seed'].reenable
-    Rake::Task['eez:seed'].invoke
+    quietly { Rake::Task['eez:seed'].invoke }
+
     Rake::Task['eez:link_locations'].reenable
-    Rake::Task['eez:link_locations'].invoke
-    # At minimum, task should run without error
+    assert_nothing_raised { quietly { Rake::Task['eez:link_locations'].invoke } }
+  end
+
+  private
+
+  def quietly
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+  ensure
+    $stdout = original_stdout
   end
 end

--- a/test/tasks/eez_rake_test.rb
+++ b/test/tasks/eez_rake_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+require 'rake'
+
+class EezRakeTest < ActiveSupport::TestCase
+  setup do
+    Mesophotic::Application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  test "eez:seed creates EEZ records from CSV" do
+    Location.where.not(eez_id: nil).update_all(eez_id: nil)
+    Eez.delete_all
+    Rake::Task['eez:seed'].reenable
+    Rake::Task['eez:seed'].invoke
+    assert Eez.count > 0, "Expected EEZ records to be created"
+    assert Eez.find_by(sovereign: "Australia").present?
+  end
+
+  test "eez:seed is idempotent" do
+    Rake::Task['eez:seed'].reenable
+    Rake::Task['eez:seed'].invoke
+    count_after_first = Eez.count
+    Rake::Task['eez:seed'].reenable
+    Rake::Task['eez:seed'].invoke
+    assert_equal count_after_first, Eez.count
+  end
+
+  test "eez:link_locations matches locations to EEZs" do
+    Rake::Task['eez:seed'].reenable
+    Rake::Task['eez:seed'].invoke
+    Rake::Task['eez:link_locations'].reenable
+    Rake::Task['eez:link_locations'].invoke
+    # At minimum, task should run without error
+  end
+end


### PR DESCRIPTION
## Summary
Add EEZ data (fix #153) from the VLIZ Marine Regions v12 dataset to mesophotic.org, enabling users to browse research by sovereign nation and territory.

- **Eez model** with 285 real VLIZ EEZ records (real MRGIDs), linked to locations via `belongs_to :eez`
- **EEZ index page** (`/eezs`) with sovereign-first accordion hierarchy, Tom Select search (countries, territories, AND location names), colored map markers by sovereign, VLIZ attribution
- **EEZ show page** with territory detail, MRGID link to marineregions.org, locations list with publication counts, map
- **Location integration** — EEZ metadata on location detail pages, Tom Select EEZ dropdown on admin forms
- **Publication filtering** — "EEZ / Country" filter in advanced search, `by_sovereign` scope
- **CSV export** — `eez_sovereign` and `eez_territory` columns added
- **Stats** — "Publications by Country" bar chart (top 25 sovereigns); reorganized world stats section with bar graphs side-by-side above maps side-by-side
- **Navigation** — "EEZ / Country" added to Categories dropdown, menu items title-cased, "Geographic Location" shortened to "Location"
- **Rake tasks** — `rake eez:seed` (idempotent, 285 records) and `rake eez:link_locations` (153 of 154 locations matched, 1 intentionally unlinked: Saya de Malha Bank / high seas)
- **Tom Select** — `maxOptions` now defaults to 1000 (was 50) to prevent truncation on large dropdowns
- **Fix** — backup.rake constant redefinition warnings silenced with `unless defined?` guards

## Deploy steps
```
rails db:migrate
rake eez:seed
rake eez:link_locations
```

## Test plan
- [x] Run `rails test` — 299 tests pass, no warnings
- [x] Run `rake eez:seed` — seeds 285 EEZ records
- [x] Run `rake eez:link_locations` — links 153 locations (Saya de Malha Bank unlinked = correct)
- [x] Visit `/eezs` — sovereign hierarchy renders, colored map shows, search finds locations by name
- [x] Visit `/eezs/:id` — territory detail with supertitle sovereign, locations, map, MRGID link
- [x] Visit `/locations/new` — EEZ dropdown present
- [x] Edit a location — can assign/change EEZ
- [x] Visit `/publications` — "EEZ / Country" in advanced filters works
- [x] Visit `/statistics/all/2023` — Publications by Country chart loads, bar graphs above maps
- [x] Download CSV — `eez_sovereign` and `eez_territory` columns present
- [x] Categories menu shows: Location, EEZ / Country, Technology / Platform, etc.
