### PR TITLE
Clean up admin forms and standardize UI patterns

### DIFF
--- a/app/assets/javascripts/image_drop.js
+++ b/app/assets/javascripts/image_drop.js
@@ -1,0 +1,62 @@
+// Image drop zone with preview. Works with Turbo Drive.
+// Usage: <div data-image-drop="field_id"> with a file input whose id matches field_id.
+
+(function() {
+  function initImageDrop(dropZone) {
+    if (dropZone.dataset.imageDropInit) return;
+    dropZone.dataset.imageDropInit = 'true';
+
+    var fieldId = dropZone.dataset.imageDrop;
+    var fileInput = document.getElementById(fieldId);
+    var preview = dropZone.querySelector('[data-image-drop-preview]');
+    var placeholder = dropZone.querySelector('[data-image-drop-placeholder]');
+
+    if (!fileInput || !preview) return;
+
+    dropZone.addEventListener('click', function() { fileInput.click(); });
+
+    dropZone.addEventListener('dragover', function(e) {
+      e.preventDefault();
+      dropZone.style.borderColor = '#0d6efd';
+      dropZone.style.backgroundColor = '#e7f1ff';
+    });
+
+    dropZone.addEventListener('dragleave', function() {
+      dropZone.style.borderColor = '#dee2e6';
+      dropZone.style.backgroundColor = '#f8f9fa';
+    });
+
+    dropZone.addEventListener('drop', function(e) {
+      e.preventDefault();
+      dropZone.style.borderColor = '#dee2e6';
+      dropZone.style.backgroundColor = '#f8f9fa';
+      var files = e.dataTransfer.files;
+      if (files.length > 0 && files[0].type.match('image.*')) {
+        fileInput.files = files;
+        showPreview(files[0]);
+      }
+    });
+
+    fileInput.addEventListener('change', function() {
+      if (this.files.length > 0) { showPreview(this.files[0]); }
+    });
+
+    function showPreview(file) {
+      var reader = new FileReader();
+      reader.onload = function(e) {
+        preview.src = e.target.result;
+        preview.style.display = '';
+        if (placeholder) placeholder.style.display = 'none';
+      };
+      reader.readAsDataURL(file);
+    }
+  }
+
+  function initAll() {
+    document.querySelectorAll('[data-image-drop]').forEach(initImageDrop);
+  }
+
+  document.addEventListener('turbo:load', initAll);
+  document.addEventListener('turbo:frame-load', initAll);
+  document.addEventListener('DOMContentLoaded', initAll);
+})();

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,8 +4,8 @@
 #
 #  id            :integer          not null, primary key
 #  site_name     :string(255)
-#  latitude      :decimal(15, 10)  default(0.0)
-#  longitude     :decimal(15, 10)  default(0.0)
+#  latitude      :decimal(15, 10)
+#  longitude     :decimal(15, 10)
 #  estimated     :boolean
 #  location_id   :integer
 #  siteable_type :string(255)

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-7">
+      <div class="col-6">
         <div class="row">
           <div class="col-4">
             <div class="mb-3">
@@ -28,73 +28,47 @@
           <%= f.label :email , class: 'required' %><br>
           <%= f.email_field :email, class: "form-control" %>
         </div>
+        <div class="mb-3">
+          <%= f.label :mastodon_handle, "Mastodon" %>
+          <small>(e.g. @user@mastodon.social)</small><br>
+          <%= f.text_field :mastodon_handle, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :bluesky_handle, "Bluesky" %>
+          <small>(e.g. mesophotic.bsky.social)</small><br>
+          <%= f.text_field :bluesky_handle, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :threads_handle, "Threads" %>
+          <small>(e.g. @mesophotic)</small><br>
+          <%= f.text_field :threads_handle, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :twitter_handle, "Twitter / X" %>
+          <small>(e.g. @mesophotic)</small><br>
+          <%= f.text_field :twitter_handle, class: "form-control" %>
+        </div>
       </div>
-      <div class="col-5">
+      <div class="col-6">
         <div class="mb-3">
           <%= f.label :profile_picture, class: 'required' %><br>
-          <div id="profile-picture-drop"
-               class="rounded-3 mb-2 d-flex align-items-center justify-content-center profile-picture-drop"
-               style="width: 244px; height: 244px; border: 2px dashed #dee2e6; cursor: pointer; overflow: hidden; background-color: #f8f9fa; position: relative; transition: all 0.15s ease;">
+          <div data-image-drop="user_profile_picture"
+               class="rounded-3 mb-2 d-flex align-items-center justify-content-center"
+               style="aspect-ratio: 1/1; height: 352px; border: 2px dashed #dee2e6; cursor: pointer; overflow: hidden; background-color: #f8f9fa; position: relative; transition: all 0.15s ease;">
             <% if @user.profile_picture.attached? %>
               <%= image_tag @user.profile_picture.variant(resize: "300x300^", crop: "300x300+0+0"),
-                            id: "profile-picture-preview",
-                            style: "width: 100%; height: 100%; object-fit: cover;" %>
+                            data: { image_drop_preview: true },
+                            style: "position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover;" %>
             <% else %>
-              <div id="profile-picture-placeholder" class="text-center text-muted">
+              <div data-image-drop-placeholder class="text-center text-muted">
                 <i class="bi bi-cloud-arrow-up" style="font-size: 2rem;"></i>
                 <br><small>Drop image or click</small>
               </div>
-              <img id="profile-picture-preview" style="width: 100%; height: 100%; object-fit: cover; display: none;">
+              <img data-image-drop-preview style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: cover; display: none;">
             <% end %>
           </div>
-          <%= f.file_field :profile_picture, class: "form-control", id: "profile-picture-input", style: "display: none;" %>
+          <%= f.file_field :profile_picture, class: "form-control" %>
         </div>
-        <script>
-          (function() {
-            var dropZone = document.getElementById('profile-picture-drop');
-            var fileInput = document.getElementById('profile-picture-input');
-            var preview = document.getElementById('profile-picture-preview');
-            var placeholder = document.getElementById('profile-picture-placeholder');
-
-            dropZone.addEventListener('click', function() { fileInput.click(); });
-
-            dropZone.addEventListener('dragover', function(e) {
-              e.preventDefault();
-              dropZone.style.borderColor = '#0d6efd';
-              dropZone.style.backgroundColor = '#e7f1ff';
-            });
-
-            dropZone.addEventListener('dragleave', function() {
-              dropZone.style.borderColor = '#dee2e6';
-              dropZone.style.backgroundColor = '#f8f9fa';
-            });
-
-            dropZone.addEventListener('drop', function(e) {
-              e.preventDefault();
-              dropZone.style.borderColor = '#dee2e6';
-              dropZone.style.backgroundColor = '#f8f9fa';
-              var files = e.dataTransfer.files;
-              if (files.length > 0 && files[0].type.match('image.*')) {
-                fileInput.files = files;
-                showPreview(files[0]);
-              }
-            });
-
-            fileInput.addEventListener('change', function() {
-              if (this.files.length > 0) { showPreview(this.files[0]); }
-            });
-
-            function showPreview(file) {
-              var reader = new FileReader();
-              reader.onload = function(e) {
-                preview.src = e.target.result;
-                preview.style.display = '';
-                if (placeholder) placeholder.style.display = 'none';
-              };
-              reader.readAsDataURL(file);
-            }
-          })();
-        </script>
       </div>
     </div>
   </div>
@@ -189,41 +163,6 @@
           <%= f.label :phone %>
           <br>
           <%= f.text_field :phone, class: "form-control" %>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-
-<%# Social media %>
-<div class="card">
-  <div class="card-header">
-    <strong>Social Media</strong>
-  </div>
-  <div class="card-body">
-    <div class="row">
-      <div class="col-6">
-        <div class="mb-3">
-          <%= f.label :mastodon_handle, "Mastodon" %>
-          <small>(e.g. @user@mastodon.social)</small><br>
-          <%= f.text_field :mastodon_handle, class: "form-control" %>
-        </div>
-        <div class="mb-3">
-          <%= f.label :bluesky_handle, "Bluesky" %>
-          <small>(e.g. mesophotic.bsky.social)</small><br>
-          <%= f.text_field :bluesky_handle, class: "form-control" %>
-        </div>
-      </div>
-      <div class="col-6">
-        <div class="mb-3">
-          <%= f.label :threads_handle, "Threads" %>
-          <small>(e.g. @mesophotic)</small><br>
-          <%= f.text_field :threads_handle, class: "form-control" %>
-        </div>
-        <div class="mb-3">
-          <%= f.label :twitter_handle, "Twitter / X" %>
-          <small>(e.g. @mesophotic)</small><br>
-          <%= f.text_field :twitter_handle, class: "form-control" %>
         </div>
       </div>
     </div>

--- a/app/views/expeditions/_form.html.erb
+++ b/app/views/expeditions/_form.html.erb
@@ -1,77 +1,95 @@
+<%# Expedition details %>
 <div class="card">
   <div class="card-header">
-    <h4 class="card-title">Expedition Metadata</h4>
+    <strong>Details</strong>
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-7">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label :title %><br>
-          <%= f.text_field :title, style: 'width:90%;' %>
+          <%= f.label :title, class: "required" %><br>
+          <%= f.text_field :title, class: "form-control", placeholder: "Expedition title" %>
         </div>
         <div class="mb-3">
           <%= f.label :description %><br>
-          <%= f.text_area :description, style: 'width:90%;',
-                          rows: 4 %>
+          <%= f.text_area :description, class: "form-control", rows: 4, placeholder: "Brief description of the expedition" %>
         </div>
         <div class="mb-3">
           <%= f.label :url %><br>
-          <%= f.text_field :url, style: 'width:90%;' %>
+          <%= f.text_field :url, class: "form-control", placeholder: "e.g. https://..." %>
         </div>
-      </div>
-      <div class="col-5">
         <div class="mb-3">
           <%= f.label :start_date %><br>
-          <%= f.date_select :start_date, start_year: 1990  %>
+          <%= f.date_select :start_date, { start_year: 1990 }, { class: "form-select d-inline-block w-auto me-1" } %>
         </div>
         <div class="mb-3">
           <%= f.label :end_date %><br>
-          <%= f.date_select :end_date, start_year: 1990 %>
+          <%= f.date_select :end_date, { start_year: 1990 }, { class: "form-select d-inline-block w-auto me-1" } %>
         </div>
+      </div>
+      <div class="col-6">
         <div class="mb-3">
           <%= f.label :featured_image %><br>
-          <%= f.file_field :featured_image %>
+          <div data-image-drop="expedition_featured_image"
+               class="rounded-3 mb-2 d-flex align-items-center justify-content-center"
+               style="max-width: 100%; aspect-ratio: 4/3; max-height: 355px; border: 2px dashed #dee2e6; cursor: pointer; overflow: hidden; background-color: #f8f9fa; position: relative; transition: all 0.15s ease;">
+            <% if @expedition.featured_image.attached? %>
+              <%= image_tag @expedition.featured_image.variant(resize: "640x480>"),
+                            data: { image_drop_preview: true },
+                            style: "position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain;" %>
+            <% else %>
+              <div data-image-drop-placeholder class="text-center text-muted">
+                <i class="bi bi-cloud-arrow-up" style="font-size: 2rem;"></i>
+                <br><small>Drop image or click</small>
+              </div>
+              <img data-image-drop-preview style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain; display: none;">
+            <% end %>
+          </div>
+          <%= f.file_field :featured_image, class: "form-control" %>
         </div>
         <div class="mb-3">
-          <%= f.label :featured_image_credits %><br>
-          <%= f.text_field :featured_image_credits %>
+          <%= f.label :featured_image_credits, "Image Credits" %><br>
+          <%= f.text_field :featured_image_credits, class: "form-control", placeholder: "e.g. John Smith" %>
         </div>
       </div>
     </div>
   </div>
 </div>
 
-<div class="card">
+<%# People %>
+<div class="card mt-3">
   <div class="card-header">
-    <h4 class="card-title">
-      Expedition researchers / organisations
-    </h4>
+    <strong>Researchers / Organisations</strong>
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-7">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label "Organisations involved:" %><br>
-          <div class="scrollbox">
-            <%= hidden_field_tag "expedition[organisation_ids][]", "" %>
-            <% for organisation in Organisation.all.order("name ASC") %>
-              <%= check_box_tag "expedition[organisation_ids][]",
-                                organisation.id,
-                                @expedition.organisations.include?(organisation) %>
-              <%= organisation.name %><br>
-            <% end %>
-          </div>
-        </div>
-      </div>
-      <div class="col-5">
-        <div class="mb-3">
-          <%= f.label "Researchers involved:" %><br>
+          <%= f.label "Researchers" %><br>
           <div class="scrollbox">
             <%= hidden_field_tag "expedition[user_ids][]", "" %>
             <% for user in User.all.order("last_name ASC, first_name ASC") %>
-              <%= check_box_tag "expedition[user_ids][]", user.id,
-                                @expedition.users.include?(user) %>
-              <%= user.first_name %> <em><%= user.last_name %></em><br>
+              <div class="form-check">
+                <%= check_box_tag "expedition[user_ids][]", user.id,
+                                  @expedition.users.include?(user), class: "form-check-input" %>
+                <label class="form-check-label"><%= user.first_name %> <em><%= user.last_name %></em></label>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="mb-3">
+          <%= f.label "Organisations" %><br>
+          <div class="scrollbox">
+            <%= hidden_field_tag "expedition[organisation_ids][]", "" %>
+            <% for organisation in Organisation.all.order("name ASC") %>
+              <div class="form-check">
+                <%= check_box_tag "expedition[organisation_ids][]",
+                                  organisation.id,
+                                  @expedition.organisations.include?(organisation), class: "form-check-input" %>
+                <label class="form-check-label"><%= organisation.name %></label>
+              </div>
             <% end %>
           </div>
         </div>
@@ -80,58 +98,65 @@
   </div>
 </div>
 
-<div class="card">
+<%# Categories %>
+<div class="card mt-3">
   <div class="card-header">
-    <h4 class="card-title">
-      Expedition metadata
-    </h4>
+    <strong>Categories</strong>
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-7">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label :platform %><br>
+          <%= f.label :platform, "Technologies / Platforms" %><br>
           <div class="scrollbox">
             <%= hidden_field_tag "expedition[platform_ids][]", "" %>
             <% for platform in Platform.all.order("LOWER(description) ASC") %>
-              <%= check_box_tag "expedition[platform_ids][]", platform.id,
-                                @expedition.platforms.include?(platform) %>
-              <%= platform.description %>&nbsp;<br>
+              <div class="form-check">
+                <%= check_box_tag "expedition[platform_ids][]", platform.id,
+                                  @expedition.platforms.include?(platform), class: "form-check-input" %>
+                <label class="form-check-label"><%= platform.description %></label>
+              </div>
             <% end %>
           </div>
         </div>
         <div class="mb-3">
-          <%= f.label :field %><br>
+          <%= f.label :field, "Research Fields" %><br>
           <div class="scrollbox">
             <%= hidden_field_tag "expedition[field_ids][]", "" %>
             <% for field in Field.all.order("LOWER(description) ASC") %>
-              <%= check_box_tag "expedition[field_ids][]", field.id,
-                                @expedition.fields.include?(field) %>
-              <%= field.description %>&nbsp;<br>
+              <div class="form-check">
+                <%= check_box_tag "expedition[field_ids][]", field.id,
+                                  @expedition.fields.include?(field), class: "form-check-input" %>
+                <label class="form-check-label"><%= field.description %></label>
+              </div>
             <% end %>
           </div>
         </div>
       </div>
-      <div class="col-5">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label :focusgroup %><br>
+          <%= f.label :focusgroup, "Focus Groups" %><br>
           <div class="scrollbox">
             <%= hidden_field_tag "expedition[focusgroup_ids][]", "" %>
             <% for focusgroup in Focusgroup.all.order("LOWER(description) ASC") %>
-              <%= check_box_tag "expedition[focusgroup_ids][]", focusgroup.id,
-                                @expedition.focusgroups.include?(focusgroup) %>
-              <%= focusgroup.description %>&nbsp;<br>
+              <div class="form-check">
+                <%= check_box_tag "expedition[focusgroup_ids][]", focusgroup.id,
+                                  @expedition.focusgroups.include?(focusgroup), class: "form-check-input" %>
+                <label class="form-check-label"><%= focusgroup.description %></label>
+              </div>
             <% end %>
           </div>
         </div>
         <div class="mb-3">
-          <%= f.label :location %><br>
+          <%= f.label :location, "Locations" %><br>
           <div class="scrollbox">
             <%= hidden_field_tag "expedition[location_ids][]", "" %>
             <% for location in Location.all.order("LOWER(description) ASC") %>
-              <%= check_box_tag "expedition[location_ids][]", location.id,
-                                @expedition.locations.include?(location) %>
-              <%= location.description %>&nbsp;<br>
+              <div class="form-check">
+                <%= check_box_tag "expedition[location_ids][]", location.id,
+                                  @expedition.locations.include?(location), class: "form-check-input" %>
+                <label class="form-check-label"><%= location.description %></label>
+              </div>
             <% end %>
           </div>
         </div>

--- a/app/views/expeditions/edit.html.erb
+++ b/app/views/expeditions/edit.html.erb
@@ -1,9 +1,21 @@
 <%= render partial: "layouts/page_title",
-       locals: {title: "Edit expedition",
-          subtitle: @expedition.title,
+       locals: {title: "Editing \"#{@expedition.title}\"",
           breadcrumbs: [["Expeditions", expeditions_path], [@expedition.title, nil]] } %>
 
 <%= form_for(@expedition) do |f| %>
+  <% if @expedition.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@expedition.errors.count, "error") %> prohibited this expedition from being saved:</h5>
+      <ul class="mb-0">
+        <% @expedition.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <%= render partial: 'form', locals: {f: f} %>
-  <div class="actions"><%= f.submit "Save Expedition", class: "btn btn-primary" %></div>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Expedition", class: "btn btn-primary" %>
+    <%= link_to "Cancel", expeditions_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/app/views/expeditions/new.html.erb
+++ b/app/views/expeditions/new.html.erb
@@ -1,9 +1,21 @@
 <%= render partial: "layouts/page_title",
-       locals: {title: "New expedition",
-          subtitle: "",
+       locals: {title: "New Expedition",
           breadcrumbs: [["Expeditions", expeditions_path], ["New", nil]] } %>
 
 <%= form_for(@expedition) do |f| %>
+  <% if @expedition.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@expedition.errors.count, "error") %> prohibited this expedition from being saved:</h5>
+      <ul class="mb-0">
+        <% @expedition.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <%= render partial: 'form', locals: {f: f} %>
-  <div class="actions"><%= f.submit "Save Expedition", class: "btn btn-primary" %></div>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Expedition", class: "btn btn-primary" %>
+    <%= link_to "Cancel", expeditions_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/app/views/layouts/_home_title.html.erb
+++ b/app/views/layouts/_home_title.html.erb
@@ -2,14 +2,8 @@
   <% title("Home") %>
 </div>
 
-<div class="row">
-  <div class="col-sm-9">
-    <h3 class="page-title">
-      The repository for scientific information on mesophotic ecosystems
-    </h3>
-  </div>
-  <div class="col-sm-3 text-sm-end">
-    <span class="badge fw-normal" style="font-size: 0.75em; color: #c7254e; background-color: #f9f2f4;"><%= l @latest_update.to_date, format: :long %></span>
-  </div>
-</div>
+<%= render partial: "layouts/page_title", locals: {
+      title: "The repository for scientific information on mesophotic ecosystems",
+      badge: content_tag(:span, l(@latest_update.to_date, format: :long), class: "badge fw-normal ms-0 ms-sm-2", style: "font-size: 0.85rem; color: #c7254e; background-color: #f9f2f4;")
+    } %>
 <hr>

--- a/app/views/layouts/_page_title.html.erb
+++ b/app/views/layouts/_page_title.html.erb
@@ -18,6 +18,7 @@
     <% end %>
     <h3 class="page-title">
       <%= title %><% if defined?(subtitle) && subtitle.present? %> <span style="font-weight: normal; font-size: 0.75em;" class="text-muted"><%= subtitle %></span><% end %>
+      <% if defined?(badge) && badge.present? %><span class="d-block d-sm-inline float-sm-end mt-1 mt-sm-0"><%= badge %></span><% end %>
     </h3>
   </div>
 </div>

--- a/app/views/layouts/_user_links.html.erb
+++ b/app/views/layouts/_user_links.html.erb
@@ -11,7 +11,10 @@
 		  <li><%= link_to "New Publication", new_publication_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Post", new_admin_post_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Photo", new_photo_path, class: "dropdown-item" %></li>
+		  <li><hr class="dropdown-divider"></li>
 		  <li><%= link_to "New Location", new_location_path, class: "dropdown-item" %></li>
+		  <li><%= link_to "New Site", new_site_path, class: "dropdown-item" %></li>
+		  <li><hr class="dropdown-divider"></li>
 		  <li><%= link_to "New Expedition", new_expedition_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Meeting", new_meeting_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Presentation", new_presentation_path, class: "dropdown-item" %></li>

--- a/app/views/layouts/_user_links.html.erb
+++ b/app/views/layouts/_user_links.html.erb
@@ -12,6 +12,7 @@
 		  <li><%= link_to "New Post", new_admin_post_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Photo", new_photo_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Location", new_location_path, class: "dropdown-item" %></li>
+		  <li><%= link_to "New Expedition", new_expedition_path, class: "dropdown-item" %></li>
 		  <li><hr class="dropdown-divider"></li>
 		  <li><%= link_to "Dashboard", admin_root_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "Database", rails_admin_path, class: "dropdown-item" %></li>

--- a/app/views/layouts/_user_links.html.erb
+++ b/app/views/layouts/_user_links.html.erb
@@ -13,6 +13,7 @@
 		  <li><%= link_to "New Photo", new_photo_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Location", new_location_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Expedition", new_expedition_path, class: "dropdown-item" %></li>
+		  <li><%= link_to "New Meeting", new_meeting_path, class: "dropdown-item" %></li>
 		  <li><hr class="dropdown-divider"></li>
 		  <li><%= link_to "Dashboard", admin_root_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "Database", rails_admin_path, class: "dropdown-item" %></li>

--- a/app/views/layouts/_user_links.html.erb
+++ b/app/views/layouts/_user_links.html.erb
@@ -14,6 +14,7 @@
 		  <li><%= link_to "New Location", new_location_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Expedition", new_expedition_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "New Meeting", new_meeting_path, class: "dropdown-item" %></li>
+		  <li><%= link_to "New Presentation", new_presentation_path, class: "dropdown-item" %></li>
 		  <li><hr class="dropdown-divider"></li>
 		  <li><%= link_to "Dashboard", admin_root_path, class: "dropdown-item" %></li>
 		  <li><%= link_to "Database", rails_admin_path, class: "dropdown-item" %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,7 @@
   <%= javascript_include_tag "feed_tabs", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "tom-select-rails/js/tom-select.complete.min", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "tom_select_init", "data-turbo-track": "reload" %>
+  <%= javascript_include_tag "image_drop", "data-turbo-track": "reload" %>
   <%= yield :head %>
   <%= javascript_include_tag "proj4", "data-turbo-track": "reload" %>
   <%= javascript_include_tag "highcharts", "data-turbo-track": "reload" %>

--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -1,85 +1,103 @@
+<%# Details %>
 <div class="card">
   <div class="card-header">
-    <h4 class="card-title">Meeting Information</h4>
+    <strong>Details</strong>
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-7">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label :title %><br>
-          <%= f.text_field :title, style: 'width:90%;' %>
+          <%= f.label :title, class: "required" %><br>
+          <%= f.text_field :title, class: "form-control", placeholder: "Meeting title" %>
         </div>
         <div class="mb-3">
           <%= f.label :description %><br>
-          <%= f.text_area :description, style: 'width:90%;',
-                          rows: 4 %>
+          <%= f.text_area :description, class: "form-control", rows: 4, placeholder: "Brief description of the meeting" %>
         </div>
         <div class="mb-3">
           <%= f.label :url %><br>
-          <%= f.text_field :url, style: 'width:90%;' %>
-        </div>
-        <div class="mb-3">
-          <%= f.label :country %><br />
-          <%= f.country_select :country, class: "form-control" %>
-        </div>
-      </div>
-      <div class="col-5">
-        <div class="mb-3">
-          <%= f.label :start_date %><br>
-          <%= f.date_select :start_date, start_year: 1990  %>
-        </div>
-        <div class="mb-3">
-          <%= f.label :end_date %><br>
-          <%= f.date_select :end_date, start_year: 1990 %>
-        </div>
-        <div class="mb-3">
-          <%= f.label :featured_image %><br>
-          <%= f.file_field :featured_image %>
-        </div>
-        <div class="mb-3">
-          <%= f.label :featured_image_credits %><br>
-          <%= f.text_field :featured_image_credits %>
+          <%= f.text_field :url, class: "form-control", placeholder: "e.g. https://..." %>
         </div>
         <div class="mb-3">
           <%= f.label :venue %><br>
-          <%= f.text_field :venue %>
+          <%= f.text_field :venue, class: "form-control", placeholder: "e.g. Convention Centre, Sydney" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :country %><br>
+          <%= f.country_select :country, { prompt: "Select country..." }, { class: "form-select" } %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :start_date %><br>
+          <%= f.date_select :start_date, { start_year: 1990 }, { class: "form-select d-inline-block w-auto me-1" } %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :end_date %><br>
+          <%= f.date_select :end_date, { start_year: 1990 }, { class: "form-select d-inline-block w-auto me-1" } %>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="mb-3">
+          <%= f.label :featured_image %><br>
+          <div data-image-drop="meeting_featured_image"
+               class="rounded-3 mb-2 d-flex align-items-center justify-content-center"
+               style="max-width: 100%; aspect-ratio: 4/3; max-height: 355px; border: 2px dashed #dee2e6; cursor: pointer; overflow: hidden; background-color: #f8f9fa; position: relative; transition: all 0.15s ease;">
+            <% if @meeting.featured_image.attached? %>
+              <%= image_tag @meeting.featured_image.variant(resize: "640x480>"),
+                            data: { image_drop_preview: true },
+                            style: "position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain;" %>
+            <% else %>
+              <div data-image-drop-placeholder class="text-center text-muted">
+                <i class="bi bi-cloud-arrow-up" style="font-size: 2rem;"></i>
+                <br><small>Drop image or click</small>
+              </div>
+              <img data-image-drop-preview style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain; display: none;">
+            <% end %>
+          </div>
+          <%= f.file_field :featured_image, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :featured_image_credits, "Image Credits" %><br>
+          <%= f.text_field :featured_image_credits, class: "form-control", placeholder: "e.g. John Smith" %>
         </div>
       </div>
     </div>
   </div>
 </div>
 
-<div class="card">
+<%# Organisers %>
+<div class="card mt-3">
   <div class="card-header">
-    <h4 class="card-title">
-      Meeting organisers
-    </h4>
+    <strong>Organisers</strong>
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-7">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label "Institutions involved in organisation:" %><br>
+          <%= f.label "Session Chairs / Organising Members" %><br>
           <div class="scrollbox">
-            <%= hidden_field_tag "meeting[organisation_ids][]", "" %>
-            <% for organisation in Organisation.all.order("name ASC") %>
-              <%= check_box_tag "meeting[organisation_ids][]",
-                                organisation.id,
-                                @meeting.organisations.include?(organisation) %>
-              <%= organisation.name %><br>
+            <%= hidden_field_tag "meeting[user_ids][]", "" %>
+            <% for user in User.all.order("last_name ASC, first_name ASC") %>
+              <div class="form-check">
+                <%= check_box_tag "meeting[user_ids][]", user.id,
+                                  @meeting.users.include?(user), class: "form-check-input" %>
+                <label class="form-check-label"><%= user.first_name %> <em><%= user.last_name %></em></label>
+              </div>
             <% end %>
           </div>
         </div>
       </div>
-      <div class="col-5">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label "Session chairs / organising members:" %><br>
+          <%= f.label "Institutions" %><br>
           <div class="scrollbox">
-            <%= hidden_field_tag "meeting[user_ids][]", "" %>
-            <% for user in User.all.order("last_name ASC, first_name ASC") %>
-              <%= check_box_tag "meeting[user_ids][]", user.id,
-                                @meeting.users.include?(user) %>
-              <%= user.first_name %> <em><%= user.last_name %></em><br>
+            <%= hidden_field_tag "meeting[organisation_ids][]", "" %>
+            <% for organisation in Organisation.all.order("name ASC") %>
+              <div class="form-check">
+                <%= check_box_tag "meeting[organisation_ids][]",
+                                  organisation.id,
+                                  @meeting.organisations.include?(organisation), class: "form-check-input" %>
+                <label class="form-check-label"><%= organisation.name %></label>
+              </div>
             <% end %>
           </div>
         </div>
@@ -88,24 +106,22 @@
   </div>
 </div>
 
-<div class="card">
+<%# Presentations %>
+<div class="card mt-3">
   <div class="card-header">
-    <h4 class="card-title">
-      Presentations
-    </h4>
+    <strong>Presentations</strong>
   </div>
   <div class="card-body">
-    <div class="mb-3">
-      <%= hidden_field_tag "meeting[presentation_ids][]", "" %>
-      <% Presentation.all.each do |presentation| %>
-        <div class="field">
-          <%= check_box_tag "meeting[presentation_ids][]",
-                            presentation.id,
-                            @meeting.presentations.include?(presentation) %>
-          <%= presentation.authors %>
-          <%= presentation.title %>
-        </div>
-      <% end %>
-    </div>
+    <%= hidden_field_tag "meeting[presentation_ids][]", "" %>
+    <% Presentation.all.each do |presentation| %>
+      <div class="form-check">
+        <%= check_box_tag "meeting[presentation_ids][]",
+                          presentation.id,
+                          @meeting.presentations.include?(presentation), class: "form-check-input" %>
+        <label class="form-check-label">
+          <%= presentation.authors %> — <%= presentation.title %>
+        </label>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/meetings/edit.html.erb
+++ b/app/views/meetings/edit.html.erb
@@ -1,9 +1,21 @@
 <%= render partial: "layouts/page_title",
-       locals: {title: "Edit meeting",
-          subtitle: @meeting.title,
+       locals: {title: "Editing \"#{@meeting.title}\"",
           breadcrumbs: [["Meetings", meetings_path], [@meeting.title, nil]] } %>
 
 <%= form_for(@meeting) do |f| %>
+  <% if @meeting.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@meeting.errors.count, "error") %> prohibited this meeting from being saved:</h5>
+      <ul class="mb-0">
+        <% @meeting.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <%= render partial: 'form', locals: {f: f} %>
-  <div class="actions"><%= f.submit "Save Meeting", class: "btn btn-primary" %></div>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Meeting", class: "btn btn-primary" %>
+    <%= link_to "Cancel", meetings_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/app/views/meetings/new.html.erb
+++ b/app/views/meetings/new.html.erb
@@ -1,9 +1,21 @@
 <%= render partial: "layouts/page_title",
-       locals: {title: "New meeting",
-          subtitle: "",
+       locals: {title: "New Meeting",
           breadcrumbs: [["Meetings", meetings_path], ["New", nil]] } %>
 
 <%= form_for(@meeting) do |f| %>
+  <% if @meeting.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@meeting.errors.count, "error") %> prohibited this meeting from being saved:</h5>
+      <ul class="mb-0">
+        <% @meeting.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <%= render partial: 'form', locals: {f: f} %>
-  <div class="actions"><%= f.submit "Save Meeting", class: "btn btn-primary" %></div>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Meeting", class: "btn btn-primary" %>
+    <%= link_to "Cancel", meetings_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/app/views/photos/_form.html.erb
+++ b/app/views/photos/_form.html.erb
@@ -1,123 +1,123 @@
+<%# Metadata %>
 <div class="card">
   <div class="card-header">
-    <h4 class="card-title">Photo Metadata</h4>
+    <strong>Metadata</strong>
   </div>
   <div class="card-body">
-    <% if @photo.image.attached? %>
-      <div class="row">
-        <div class="col-12">
-          <div style="background-color: #f0f1f3;">
-            <%= image_tag @photo.image.variant(resize: "640x480>"), style: "width: 100%;" %>
-          </div>
-          <hr>
-        </div>
-      </div>
-    <% end %>
-
     <div class="row">
-      <div class="col-7">
-        <div class="mb-3">
-          <%= f.label :image %><br>
-          <%= f.file_field :image %>
-        </div>
+      <div class="col-6">
         <div class="mb-3">
           <%= f.label :description %><br>
-          <%= f.text_field :description, style: 'width:90%;',
-                           class: "form-control monospaced-control"  %>
+          <%= f.text_field :description, class: "form-control", placeholder: "Brief description of the photo" %>
         </div>
         <div class="mb-3">
-          <%= f.label :credit %>&nbsp;
-          <small>
-            (do not include a copyright symbol - this will automatically
-            be added)
-          </small><br>
-          <%= f.text_field :credit, style: 'width:90%;',
-                           class: "form-control monospaced-control"  %>
+          <%= f.label :credit %> <small class="text-muted">(do not include a copyright symbol)</small><br>
+          <%= f.text_field :credit, class: "form-control", placeholder: "e.g. John Smith" %>
         </div>
         <div class="mb-3">
           <%= f.label :photographer %><br>
           <%= f.collection_select :photographer_id,
                                   User.all.order("last_name ASC, first_name ASC"),
                                   :id, :full_name,
-                                  :include_blank => true,
-                                  class: "form-control" %>
+                                  { include_blank: "Select photographer..." },
+                                  { class: "form-select", "data-tom-select" => "" } %>
         </div>
-        <div class="mb-3">
-          <%= f.check_box :creative_commons %>
-          <%= f.label "Creative Commons license applies" %>
-        </div>
-      </div>
-      <div class="col-5">
         <div class="mb-3">
           <%= f.label :location %><br>
           <%= f.collection_select :location_id,
                                   Location.all.order("description ASC"),
                                   :id, :description,
-                                  :include_blank => true,
-                                  class: "form-control" %>
+                                  { include_blank: "Select location..." },
+                                  { class: "form-select", "data-tom-select" => "" } %>
         </div>
         <div class="mb-3">
           <%= f.label :site %><br>
           <%= f.collection_select :site_id,
                                   Site.all.order("site_name ASC"),
                                   :id, :site_name,
-                                  :include_blank => true,
-                                  class: "form-control" %>
+                                  { include_blank: "Select site..." },
+                                  { class: "form-select", "data-tom-select" => "" } %>
         </div>
         <div class="mb-3">
-          <%= f.label :depth %> <small>(use `0` for surface shots and '-1' for unknown depth)</small><br>
-          <%= f.text_field :depth,
-              class: "form-control monospaced-control",
-              value: 0 %>
+          <%= f.label :depth %> <small class="text-muted">(0 for surface, -1 for unknown)</small><br>
+          <%= f.text_field :depth, class: "form-control", placeholder: "e.g. 45" %>
         </div>
-        <div class="mb-3">
-          <%= f.check_box :contains_species %>
-          <%= f.label "Photo contains species" %>
+        <div class="form-check">
+          <%= f.check_box :creative_commons, class: "form-check-input" %>
+          <%= f.label :creative_commons, "Creative Commons license applies", class: "form-check-label" %>
         </div>
-        <div class="mb-3">
-          <%= f.check_box :underwater %>
-          <%= f.label "Photo taken underwater" %>
+        <div class="form-check">
+          <%= f.check_box :contains_species, class: "form-check-input" %>
+          <%= f.label :contains_species, "Photo contains species", class: "form-check-label" %>
         </div>
+        <div class="form-check">
+          <%= f.check_box :underwater, class: "form-check-input" %>
+          <%= f.label :underwater, "Photo taken underwater", class: "form-check-label" %>
+        </div>
+        <div class="form-check">
+          <%= f.check_box :showcases_location, class: "form-check-input" %>
+          <%= f.label :showcases_location, "Feature on location page", class: "form-check-label" %>
+        </div>
+      </div>
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.check_box :showcases_location %>
-          <%= f.label "Photo should be featured on Location page" %>
+          <%= f.label :image, class: "required" %><br>
+          <div data-image-drop="photo_image"
+               class="rounded-3 mb-2 d-flex align-items-center justify-content-center"
+               style="max-width: 100%; aspect-ratio: 4/3; max-height: 355px; border: 2px dashed #dee2e6; cursor: pointer; overflow: hidden; background-color: #f8f9fa; position: relative; transition: all 0.15s ease;">
+            <% if @photo.image.attached? %>
+              <%= image_tag @photo.image.variant(resize: "640x480>"),
+                            data: { image_drop_preview: true },
+                            style: "position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain;" %>
+            <% else %>
+              <div data-image-drop-placeholder class="text-center text-muted">
+                <i class="bi bi-cloud-arrow-up" style="font-size: 2rem;"></i>
+                <br><small>Drop image or click</small>
+              </div>
+              <img data-image-drop-preview style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; object-fit: contain; display: none;">
+            <% end %>
+          </div>
+          <%= f.file_field :image, class: "form-control" %>
         </div>
       </div>
     </div>
   </div>
 </div>
 
-<div class="card">
+<%# Researchers / Organisations %>
+<div class="card mt-3">
   <div class="card-header">
-    <h4 class="card-title">
-      Tag researchers / organisations depicted in the photo
-    </h4>
+    <strong>Researchers / Organisations</strong>
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-5">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label "Researchers:" %><br>
+          <%= f.label "Researchers" %><br>
           <div class="scrollbox">
             <%= hidden_field_tag "photo[user_ids][]", "" %>
             <% for user in User.all.order("last_name ASC, first_name ASC") %>
-              <%= check_box_tag "photo[user_ids][]", user.id,
-                                @photo.users.include?(user) %>
-              <%= user.first_name %> <em><%= user.last_name %></em><br>
+              <div class="form-check">
+                <%= check_box_tag "photo[user_ids][]", user.id,
+                                  @photo.users.include?(user), class: "form-check-input" %>
+                <label class="form-check-label"><%= user.first_name %> <em><%= user.last_name %></em></label>
+              </div>
             <% end %>
           </div>
         </div>
       </div>
-      <div class="col-7">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label "Organisations:" %><br>
+          <%= f.label "Organisations" %><br>
           <div class="scrollbox">
             <%= hidden_field_tag "photo[organisation_ids][]", "" %>
             <% for organisation in Organisation.all.order("name ASC") %>
-              <%= check_box_tag "photo[organisation_ids][]",
-                                organisation.id,
-                                @photo.organisations.include?(organisation) %>
-              <%= organisation.name %><br>
+              <div class="form-check">
+                <%= check_box_tag "photo[organisation_ids][]",
+                                  organisation.id,
+                                  @photo.organisations.include?(organisation), class: "form-check-input" %>
+                <label class="form-check-label"><%= organisation.name %></label>
+              </div>
             <% end %>
           </div>
         </div>
@@ -126,42 +126,42 @@
   </div>
 </div>
 
-<div class="card">
+<%# Categories %>
+<div class="card mt-3">
   <div class="card-header">
-    <h4 class="card-title">
-      Tag technologies / species depicted in the photo
-    </h4>
+    <strong>Categories</strong>
   </div>
   <div class="card-body">
     <div class="row">
-      <div class="col-7">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label :platforms %><br>
+          <%= f.label :platforms, "Technologies / Platforms" %><br>
           <div class="scrollbox">
             <%= hidden_field_tag "photo[platform_ids][]", "" %>
             <% for platform in Platform.all.order("LOWER(description) ASC") %>
-              <%= check_box_tag "photo[platform_ids][]", platform.id,
-                                @photo.platforms.include?(platform) %>
-              <%= platform.description %>&nbsp;<br>
+              <div class="form-check">
+                <%= check_box_tag "photo[platform_ids][]", platform.id,
+                                  @photo.platforms.include?(platform), class: "form-check-input" %>
+                <label class="form-check-label"><%= platform.description %></label>
+              </div>
             <% end %>
           </div>
         </div>
       </div>
-      <div class="col-5">
+      <div class="col-6">
         <div class="mb-3">
-          <%= f.label :species %><br>
-          Not yet available.
+          <%= f.label :species, "Species" %><br>
+          <span class="text-muted">Not yet available.</span>
         </div>
       </div>
     </div>
   </div>
 </div>
 
-<div class="card">
+<%# Link to entities %>
+<div class="card mt-3">
   <div class="card-header">
-    <h4 class="card-title">
-      Link photo to specific entities:
-    </h4>
+    <strong>Link to Entities</strong>
   </div>
   <div class="card-body">
     <div class="row">
@@ -171,34 +171,34 @@
           <%= f.collection_select :publication_id,
                                   Publication.all.order("authors ASC, publication_year ASC"),
                                   :id, :short_citation_with_title,
-                                  :include_blank => true,
-                                  class: "form-control" %>
+                                  { include_blank: "Select publication..." },
+                                  { class: "form-select", "data-tom-select" => "" } %>
         </div>
         <div class="mb-3">
           <%= f.label :expedition %><br>
           <%= f.collection_select :expedition_id,
-                                  Expedition.find_each,
+                                  Expedition.all.order("title ASC"),
                                   :id, :title,
-                                  :include_blank => true,
-                                  class: "form-control" %>
+                                  { include_blank: "Select expedition..." },
+                                  { class: "form-select", "data-tom-select" => "" } %>
         </div>
       </div>
       <div class="col-6">
         <div class="mb-3">
           <%= f.label :meeting %><br>
           <%= f.collection_select :meeting_id,
-                                  Meeting.find_each,
+                                  Meeting.all.order("title ASC"),
                                   :id, :title,
-                                  :include_blank => true,
-                                  class: "form-control" %>
+                                  { include_blank: "Select meeting..." },
+                                  { class: "form-select", "data-tom-select" => "" } %>
         </div>
         <div class="mb-3">
           <%= f.label :post %><br>
           <%= f.collection_select :post_id,
-                                  Post.find_each,
+                                  Post.all.order("title ASC"),
                                   :id, :title,
-                                  :include_blank => true,
-                                  class: "form-control" %>
+                                  { include_blank: "Select post..." },
+                                  { class: "form-select", "data-tom-select" => "" } %>
         </div>
       </div>
     </div>

--- a/app/views/photos/edit.html.erb
+++ b/app/views/photos/edit.html.erb
@@ -1,9 +1,21 @@
 <%= render partial: "layouts/page_title",
-       	   locals: {title: "Edit photo",
-           subtitle: @photo.description,
-           breadcrumbs: [["Images", photos_path], [@photo.description_truncated, nil]] } %>
+       locals: {title: "Editing \"#{@photo.description_truncated}\"",
+          breadcrumbs: [["Images", photos_path], [@photo.description_truncated, nil]] } %>
 
 <%= form_for(@photo) do |f| %>
+  <% if @photo.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@photo.errors.count, "error") %> prohibited this photo from being saved:</h5>
+      <ul class="mb-0">
+        <% @photo.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <%= render partial: 'form', locals: {f: f} %>
-  <div class="actions"><%= f.submit "Save Photo", class: "btn btn-primary" %></div>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Photo", class: "btn btn-primary" %>
+    <%= link_to "Cancel", photos_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/app/views/photos/new.html.erb
+++ b/app/views/photos/new.html.erb
@@ -1,9 +1,21 @@
 <%= render partial: "layouts/page_title",
-       	   locals: {title: "New photo",
-           subtitle: "",
-           breadcrumbs: [["Images", photos_path], ["New", nil]] } %>
+       locals: {title: "New Photo",
+          breadcrumbs: [["Images", photos_path], ["New", nil]] } %>
 
 <%= form_for(@photo) do |f| %>
+  <% if @photo.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@photo.errors.count, "error") %> prohibited this photo from being saved:</h5>
+      <ul class="mb-0">
+        <% @photo.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <%= render partial: 'form', locals: {f: f} %>
-  <div class="actions"><%= f.submit "Save Photo", class: "btn btn-primary" %></div>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Photo", class: "btn btn-primary" %>
+    <%= link_to "Cancel", photos_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/app/views/presentations/_form.html.erb
+++ b/app/views/presentations/_form.html.erb
@@ -1,53 +1,50 @@
-<%= form_for(@presentation) do |f| %>
-  <% if @presentation.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@presentation.errors.count, "error") %> prohibited this presentation from being saved:</h2>
-
-      <ul>
-      <% @presentation.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
+<%# Details %>
+<div class="card">
+  <div class="card-header">
+    <strong>Details</strong>
+  </div>
+  <div class="card-body">
+    <div class="row">
+      <div class="col-6">
+        <div class="mb-3">
+          <%= f.label :title, class: "required" %><br>
+          <%= f.text_field :title, class: "form-control", placeholder: "Presentation title" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :authors, class: "required" %><br>
+          <%= f.text_area :authors, class: "form-control", rows: 3, placeholder: "Author names" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :abstract %><br>
+          <%= f.text_area :abstract, class: "form-control", rows: 5, placeholder: "Abstract text" %>
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="mb-3">
+          <%= f.label :session %><br>
+          <%= f.text_field :session, class: "form-control", placeholder: "e.g. Session 3A" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :date %><br>
+          <%= f.text_field :date, class: "form-control", placeholder: "e.g. 2024-06-15" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :time %><br>
+          <%= f.text_field :time, class: "form-control", placeholder: "e.g. 14:30" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :location %><br>
+          <%= f.text_field :location, class: "form-control", placeholder: "e.g. Room 201" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :poster_id, "Poster ID" %><br>
+          <%= f.number_field :poster_id, class: "form-control", placeholder: "e.g. 42" %>
+        </div>
+        <div class="form-check">
+          <%= f.check_box :oral, class: "form-check-input" %>
+          <%= f.label :oral, "Oral presentation", class: "form-check-label" %>
+        </div>
+      </div>
     </div>
-  <% end %>
-
-  <div class="field">
-    <%= f.label :title %><br>
-    <%= f.text_field :title %>
   </div>
-  <div class="field">
-    <%= f.label :abstract %><br>
-    <%= f.text_area :abstract %>
-  </div>
-  <div class="field">
-    <%= f.label :authors %><br>
-    <%= f.text_area :authors %>
-  </div>
-  <div class="field">
-    <%= f.label :oral %><br>
-    <%= f.check_box :oral %>
-  </div>
-  <div class="field">
-    <%= f.label :session %><br>
-    <%= f.text_field :session %>
-  </div>
-  <div class="field">
-    <%= f.label :date %><br>
-    <%= f.text_field :date %>
-  </div>
-  <div class="field">
-    <%= f.label :time %><br>
-    <%= f.text_field :time %>
-  </div>
-  <div class="field">
-    <%= f.label :location %><br>
-    <%= f.text_field :location %>
-  </div>
-  <div class="field">
-    <%= f.label :poster_id %><br>
-    <%= f.number_field :poster_id %>
-  </div>
-  <div class="actions">
-    <%= f.submit "Save Presentation", class: "btn btn-primary" %>
-  </div>
-<% end %>
+</div>

--- a/app/views/presentations/edit.html.erb
+++ b/app/views/presentations/edit.html.erb
@@ -1,6 +1,21 @@
-<h1>Editing Presentation</h1>
+<%= render partial: "layouts/page_title",
+       locals: {title: "Editing \"#{@presentation.title}\"",
+          breadcrumbs: [["Presentations", presentations_path], [@presentation.title, nil]] } %>
 
-<%= render 'form' %>
-
-<%= link_to 'Show', @presentation %> |
-<%= link_to 'Back', presentations_path %>
+<%= form_for(@presentation) do |f| %>
+  <% if @presentation.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@presentation.errors.count, "error") %> prohibited this presentation from being saved:</h5>
+      <ul class="mb-0">
+        <% @presentation.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= render partial: 'form', locals: {f: f} %>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Presentation", class: "btn btn-primary" %>
+    <%= link_to "Cancel", presentations_path, class: "btn btn-outline-secondary" %>
+  </div>
+<% end %>

--- a/app/views/presentations/new.html.erb
+++ b/app/views/presentations/new.html.erb
@@ -1,5 +1,21 @@
-<h1>New Presentation</h1>
+<%= render partial: "layouts/page_title",
+       locals: {title: "New Presentation",
+          breadcrumbs: [["Presentations", presentations_path], ["New", nil]] } %>
 
-<%= render 'form' %>
-
-<%= link_to 'Back', presentations_path %>
+<%= form_for(@presentation) do |f| %>
+  <% if @presentation.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@presentation.errors.count, "error") %> prohibited this presentation from being saved:</h5>
+      <ul class="mb-0">
+        <% @presentation.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= render partial: 'form', locals: {f: f} %>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Presentation", class: "btn btn-primary" %>
+    <%= link_to "Cancel", presentations_path, class: "btn btn-outline-secondary" %>
+  </div>
+<% end %>

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -1,32 +1,48 @@
-<div class="card">
-  <div class="card-header">
-    <h4 class="card-title">Site</h4>
-  </div>
-  <div class="card-body">
-    <div class="row">
-      <div class="col-7">
+<div class="row">
+  <div class="col-6">
+    <div class="card h-100">
+      <div class="card-header">
+        <strong>Details</strong>
+      </div>
+      <div class="card-body">
         <div class="mb-3">
-          <%= f.label :site_name %><br>
-          <%= f.text_field :site_name, style: 'width:90%;' %>
+          <%= f.label :site_name, "Name", class: "required" %><br>
+          <%= f.text_field :site_name, class: "form-control", placeholder: "e.g. Osprey Reef" %>
         </div>
         <div class="mb-3">
-          <%= f.label :latitude %><br>
-          <%= f.text_field :latitude, style: 'width:90%;' %>
+          <%= f.label :latitude, class: "required" %><br>
+          <%= f.text_field :latitude, class: "form-control", placeholder: "e.g. -16.447284" %>
         </div>
         <div class="mb-3">
-          <%= f.label :longitude %><br>
-          <%= f.text_field :longitude, style: 'width:90%;' %>
+          <%= f.label :longitude, class: "required" %><br>
+          <%= f.text_field :longitude, class: "form-control", placeholder: "e.g. 145.81735" %>
         </div>
         <div class="mb-3">
-          <%= f.label :location %><br />
-          <%= f.collection_select :location_id, 
-                                  Location.find_each, 
-                                  :id, :description, 
-                                  class: "form-control" %>
+          <%= f.label :location %><br>
+          <%= f.collection_select :location_id,
+                                  Location.all.order("description ASC"),
+                                  :id, :description,
+                                  { include_blank: "Select location..." },
+                                  { class: "form-select", "data-tom-select" => "" } %>
         </div>
       </div>
-      <div class="col-5" style="min-height: 230px;">
-        <%= turbo_frame_tag "world-map-sites_form", src: world_map_path(key: "sites_form", model: Site, ids: site.id, height: 230, z: 10), loading: :lazy %>
+    </div>
+  </div>
+  <div class="col-6">
+    <div class="card h-100">
+      <div class="card-header">
+        <strong>Map</strong>
+      </div>
+      <div class="card-body d-flex flex-column p-2">
+        <% if site.persisted? %>
+          <%= turbo_frame_tag "world-map-sites_form", src: world_map_path(key: "sites_form", model: Site, ids: site.id, height: 230, z: 10), loading: :lazy, class: "flex-grow-1" %>
+        <% else %>
+          <div data-chart="map-preview"
+               data-lat-field="site_latitude"
+               data-lon-field="site_longitude"
+               data-name-field="site_site_name"
+               class="flex-grow-1" style="min-height: 200px;"></div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,9 +1,21 @@
 <%= render partial: "layouts/page_title",
-	       locals: {title: "Edit site",
-	          subtitle: "#{@site.site_name}",
-	          breadcrumbs: [["Sites", sites_path], [@site.site_name, nil]] } %>
+       locals: {title: "Editing \"#{@site.site_name}\"",
+          breadcrumbs: [["Sites", sites_path], [@site.site_name, nil]] } %>
 
 <%= form_for(@site) do |f| %>
+  <% if @site.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@site.errors.count, "error") %> prohibited this site from being saved:</h5>
+      <ul class="mb-0">
+        <% @site.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <%= render partial: 'form', locals: {f: f, site: @site} %>
-  <div class="actions"><%= f.submit "Save Site", class: "btn btn-primary" %></div>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Site", class: "btn btn-primary" %>
+    <%= link_to "Cancel", sites_path, class: "btn btn-outline-secondary" %>
+  </div>
 <% end %>

--- a/app/views/sites/new.html.erb
+++ b/app/views/sites/new.html.erb
@@ -1,5 +1,21 @@
-<h1>New Site</h1>
+<%= render partial: "layouts/page_title",
+       locals: {title: "New Site",
+          breadcrumbs: [["Sites", sites_path], ["New", nil]] } %>
 
-<%= render 'form' %>
-
-<%= link_to 'Back', sites_path %>
+<%= form_for(@site) do |f| %>
+  <% if @site.errors.any? %>
+    <div class="alert alert-danger">
+      <h5><%= pluralize(@site.errors.count, "error") %> prohibited this site from being saved:</h5>
+      <ul class="mb-0">
+        <% @site.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= render partial: 'form', locals: {f: f, site: @site} %>
+  <div class="d-flex gap-2 mt-3">
+    <%= f.submit "Save Site", class: "btn btn-primary" %>
+    <%= link_to "Cancel", sites_path, class: "btn btn-outline-secondary" %>
+  </div>
+<% end %>

--- a/app/views/stats/index.html.erb
+++ b/app/views/stats/index.html.erb
@@ -4,7 +4,7 @@
 <%= render partial: "layouts/page_title", locals: {
       title: @stats_subtitle,
       supertitle: @title,
-      subtitle: raw("<span class=\"badge fw-normal float-end\" style=\"font-size: 0.65em; color: #c7254e; background-color: #f9f2f4;\">#{l @latest_update.to_date, format: :long}</span>"),
+      badge: content_tag(:span, l(@latest_update.to_date, format: :long), class: "badge fw-normal ms-0 ms-sm-2", style: "font-size: 0.85rem; color: #c7254e; background-color: #f9f2f4;"),
       breadcrumbs: [["Stats", nil]]
     } %>
 <div class="row">

--- a/db/migrate/20260412084721_change_site_coordinate_defaults_to_null.rb
+++ b/db/migrate/20260412084721_change_site_coordinate_defaults_to_null.rb
@@ -1,0 +1,6 @@
+class ChangeSiteCoordinateDefaultsToNull < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :sites, :latitude, from: 0.0, to: nil
+    change_column_default :sites, :longitude, from: 0.0, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_12_030155) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_12_084721) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.integer "blob_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -401,9 +401,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_12_030155) do
   create_table "sites", force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.boolean "estimated", limit: 1
-    t.decimal "latitude", precision: 15, scale: 10, default: "0.0"
+    t.decimal "latitude", precision: 15, scale: 10
     t.integer "location_id", limit: 4
-    t.decimal "longitude", precision: 15, scale: 10, default: "0.0"
+    t.decimal "longitude", precision: 15, scale: 10
     t.string "site_name", limit: 255
     t.string "siteable_type", limit: 255
     t.datetime "updated_at", precision: nil, null: false

--- a/lib/tasks/sites.rake
+++ b/lib/tasks/sites.rake
@@ -1,0 +1,68 @@
+namespace :sites do
+  desc "Fix sites with 0,0 coordinates and assign missing locations"
+  task fix_coordinates: :environment do
+    coordinate_fixes = {
+      "Tsitsikamma National Park" => { latitude: -33.988, longitude: 23.846 },
+      "Eilat"                     => { latitude: 29.558, longitude: 34.948 },
+      "American Shoal"            => { latitude: 24.522, longitude: -81.518 },
+      "Ant Atoll"                 => { latitude: 6.776, longitude: 157.961 },
+      "Flower Garden Banks National Marine Sanctuary" => { latitude: 27.900, longitude: -93.600 },
+      "Carrie Bow Cay"            => { latitude: 16.803, longitude: -88.082 },
+      "Florida Straits"           => { latitude: 24.060, longitude: -81.100 },
+      "San Andres"                => { latitude: 12.500, longitude: -81.700 },
+      "Cartagena"                 => { latitude: 10.270, longitude: -75.600 },
+      "Ningaloo"                  => { latitude: -21.873, longitude: 113.974 },
+      "Cozumel"                   => { latitude: 20.423, longitude: -86.922 },
+      "João Pessoa"               => { latitude: -7.120, longitude: -34.845 },
+      "Gotland"                   => { latitude: 57.845, longitude: 18.567 },
+      "Rottnest Island"           => { latitude: -32.006, longitude: 115.507 },
+    }
+
+    # Map site names to location descriptions for orphaned sites
+    location_fixes = {
+      "Ant Atoll"                 => "Micronesia - Caroline Islands (Pohnpei)",
+      "Flower Garden Banks National Marine Sanctuary" => "USA - Gulf of Mexico",
+      "Carrie Bow Cay"            => "Belize",
+      "Florida Straits"           => "USA - Continental Atlantic Ocean",
+      "San Andres"                => "Colombia - Caribbean Sea",
+      "Cartagena"                 => "Colombia - Caribbean Sea",
+      "Ningaloo"                  => "Australia - Western Australia",
+      "Cozumel"                   => "Mexico - Caribbean Sea",
+      "João Pessoa"               => "Brazil - Eastern Brazil",
+      "Gotland"                   => "Sweden",
+      "Rottnest Island"           => "Australia - Western Australia",
+    }
+
+    # Fix coordinates
+    fixed_coords = 0
+    Site.where(latitude: 0.0, longitude: 0.0).find_each do |site|
+      if coordinate_fixes.key?(site.site_name)
+        coords = coordinate_fixes[site.site_name]
+        site.update_columns(latitude: coords[:latitude], longitude: coords[:longitude])
+        puts "Coords: #{site.site_name} -> #{coords[:latitude]}, #{coords[:longitude]}"
+        fixed_coords += 1
+      else
+        puts "Skipped: #{site.site_name} (unknown coordinates, left at 0,0)"
+      end
+    end
+
+    # Fix missing locations
+    fixed_locs = 0
+    Site.where(location_id: nil).find_each do |site|
+      if location_fixes.key?(site.site_name)
+        location = Location.find_by(description: location_fixes[site.site_name])
+        if location
+          site.update_columns(location_id: location.id)
+          puts "Location: #{site.site_name} -> #{location.description}"
+          fixed_locs += 1
+        else
+          puts "Location not found: #{location_fixes[site.site_name]} for #{site.site_name}"
+        end
+      else
+        puts "Skipped: #{site.site_name} (no location mapping)"
+      end
+    end
+
+    puts "Fixed #{fixed_coords} coordinates, #{fixed_locs} locations"
+  end
+end


### PR DESCRIPTION
## Summary
Standardize all admin new/edit forms to match established conventions, add missing admin menu links, and fix several UI issues.

**Photo forms:**
- Card-based layout with `<strong>` headers, title case section names
- Tom Select on all dropdowns (photographer, location, site, publication, expedition, meeting, post)
- 4:3 image drop zone with drag/drop preview and file picker
- Reusable `image_drop.js` for Turbo-compatible image upload previews
- form-control/form-select/form-check classes, placeholders
- Separate Researchers/Organisations and Categories sections
- Fix profile picture uploader (missing closing div, now uses shared image_drop.js)

**Expedition forms:**
- Same card/header/button conventions
- Image drop zone for featured image
- Bootstrap date selects
- Researchers/Organisations and Categories sections

**Meeting forms:**
- Same conventions
- Image drop zone for featured image
- Organisers and Presentations sections

**Presentation forms:**
- Replace raw scaffold HTML with page_title partial, breadcrumbs, cards
- Details left, scheduling right

**Site forms:**
- Fix crash on new site (nil ID map issue)
- Live map preview with coordinate marker (same as locations)
- Tom Select on location dropdown
- Change lat/lon database default from 0.0 to nil
- Rake task to fix known 0,0 sites with real coordinates

**Admin menu:**
- Add New Location, Expedition, Meeting, Presentation, Site
- Group items: content (Publication/Post/Photo), geography (Location/Site), events (Expedition/Meeting/Presentation)

**All forms:**
- Title case page titles
- `Editing "Name"` pattern on edit pages
- Error display with alert-danger
- Save + Cancel button pair with proper spacing

**Other:**
- Unified date badge in page_title partial (home page + stats page)
- Responsive: badge wraps under title at small widths
- Profile page: social media fields moved into User Profile section

## Deploy steps
```
rails db:migrate
rake sites:fix_coordinates
```

## Test plan
- [x] Run `rails test` — 299 tests pass
- [x] Visit each new/edit form: photos, expeditions, meetings, presentations, sites
- [x] Image drop zones: click, drag/drop, preview all work
- [x] Tom Select dropdowns searchable on all forms
- [x] Admin menu shows grouped items with separators
- [x] Home page and stats page date badges match styling
- [x] Profile edit page renders correctly (no nested sections)
- [x] New site page renders without crash